### PR TITLE
update event_listener docker image

### DIFF
--- a/src/translation/event_listener/requirements.txt
+++ b/src/translation/event_listener/requirements.txt
@@ -1,5 +1,6 @@
 Flask==2.1.0
 gunicorn==20.1.0
+Werkzeug==2.2.2
 google-cloud-logging
 google-api-python-client
 google-auth


### PR DESCRIPTION
For event_listener docker image, we have updated werkzeug package to 2.2.2 to resolve import error:
ref: https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls