### PR TITLE
fix: agent controller starvation

### DIFF
--- a/src/datamigration/scripts/teradata/agent_controller/scripts/start_agent.sh
+++ b/src/datamigration/scripts/teradata/agent_controller/scripts/start_agent.sh
@@ -36,14 +36,15 @@ fi
 date
 echo "Transfer ID: $transfer_id"
 
-mem_free=$(free | grep Mem | awk '{print $4/$2 * 100.0}' | cut -d . -f 1)
+# (available / total) * 100
+mem_free=$(free | grep Mem | awk '{print $7/$2 * 100.0}' | cut -d . -f 1)
 while [ $mem_free -lt 30 ]
 do
    date
    echo "Memory Free: $mem_free%"
    echo "Sleeping 60 seconds"
    sleep 60
-   mem_free=$(free | grep Mem | awk '{print $4/$2 * 100.0}' | cut -d . -f 1)
+   mem_free=$(free | grep Mem | awk '{print $7/$2 * 100.0}' | cut -d . -f 1)
 done
 
 echo "Memory Free: $mem_free%"

--- a/src/translation/event_listener/main.py
+++ b/src/translation/event_listener/main.py
@@ -12,8 +12,14 @@ app = Flask(__name__)
 @app.route("/", methods=["POST"])
 def index():
     valid_subfolders_list = ["ddl", "dml", "sql", "data"]
-    event_json = request.get_json()
-    print(f"event_json: {event_json}")
+
+    if not request.is_json:
+        print("pushed message without body")
+        return errors.NO_BODY
+    else:
+        event_json = request.get_json()
+        print(f"event_json: {event_json}")
+
     if not event_json:
         print("pushed message without body")
         return errors.NO_BODY


### PR DESCRIPTION
Update `start_agent.sh` to use `available` memory instead of `free` memory from `free` cli output to consider buff/cache in calculation

Fixes : https://github.com/GoogleCloudPlatform/data-migration-tool/issues/17