### PR TITLE
Update Teradata Agent VM default sizes and docs fixes

### DIFF
--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -239,126 +239,12 @@ Storage Admin
 **To assign these roles, you can execute the Bash script cloudbuild-sa-iam-setup.sh present in the root directory**
 
 ```
-export BUILD_ACCOUNT=<CLOUDBUILD_SERVICE_ACCOUNT>  # If not specified, default Cloud Build SA is used.
+export BUILD_ACCOUNT=<CLOUDBUILD_SERVICE_ACCOUNT>  # If not specified, the default Cloud Build SA is used.
 
 bash cloudbuild-sa-iam-setup.sh
 ```
 
-Once the execution of the bash script is successful, you can proceed directly to the next step [Deploying DMT Infrastructure](#deploying-dmt-infrastructure)
-
-While we strongly recommend using the above script instead, you can also assign the roles by running these `gcloud` commands from your cloud shell.
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/bigquery.admin"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/run.admin"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/composer.admin"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/compute.instanceAdmin.v1"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/compute.networkAdmin"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/iam.serviceAccountCreator"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/logging.viewer"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/resourcemanager.projectIamAdmin"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/pubsub.admin"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/secretmanager.admin"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/iam.serviceAccountUser"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/serviceusage.serviceUsageAdmin"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/storage.admin"
-```
-
-
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:$BUILD_ACCOUNT" \
---role="roles/artifactregistry.admin"
-```
-
+Once the execution of the bash script is successful, you can proceed to the next step [Deploying DMT Infrastructure](#deploying-dmt-infrastructure).
 
 
 ## Deploying DMT infrastructure
@@ -482,7 +368,7 @@ Perform below predeployment steps to setup/configure shared VPC for composer -
       ```
 
       ```
-      gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
+      gcloud projects add-iam-policy-binding $HOST_PROJECT \
       --member="serviceAccount:$GOOGLE_API_SERVICE_AGENT" \
       --role="roles/compute.networkUser"
       ```
@@ -496,41 +382,41 @@ Perform below predeployment steps to setup/configure shared VPC for composer -
 
 
       ```
-      gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
+      gcloud projects add-iam-policy-binding $HOST_PROJECT \
       --member="serviceAccount:$GKE_SERVICE_AGENT" \
       --role="roles/compute.networkUser"
       ```
 
 
       ```
-      gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
+      gcloud projects add-iam-policy-binding $HOST_PROJECT \
       --member="serviceAccount:$GKE_SERVICE_AGENT" \
       --role="roles/container.hostServiceAgentUser"
       ```
 
 
-      d. Provide Permission to Composer Service Agent
+      d. Provide Permission to Composer Service Agent ([Composer public docs](https://cloud.google.com/composer/docs/composer-2/configure-shared-vpc))
 
-         1. Either provide **Composer Shared VPC Agent** Permission to Composer Service Agent Account in case for **Private environment**
+         1. For **Private IP environments**, grant the **Composer Shared VPC Agent** permission to the Composer Service Agent Account
 
          ```
          export COMPOSER_SERVICE_AGENT=service-$SERVICE_PROJECT_NUMBER@cloudcomposer-accounts.iam.gserviceaccount.com
          ```
 
          ```
-            gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
+            gcloud projects add-iam-policy-binding $HOST_PROJECT \
             --member="serviceAccount:$COMPOSER_SERVICE_AGENT" \
             --role="roles/composer.sharedVpcAgent"
          ```
 
-         Or, Provide **Compute Network User** Permission to Composer Agent Service Account in case for **Public environment**
+         2. OR, for  **Public IP environments**, grant the **Compute Network User** permission to Composer Agent Service Account instead
 
          ```
          export COMPOSER_SERVICE_AGENT=service-$SERVICE_PROJECT_NUMBER@cloudcomposer-accounts.iam.gserviceaccount.com
          ```
 
          ```
-            gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
+            gcloud projects add-iam-policy-binding $HOST_PROJECT \
             --member="serviceAccount:$COMPOSER_SERVICE_AGENT" \
             --role="roles/compute.networkUser"
          ```
@@ -942,11 +828,11 @@ gcloud compute firewall-rules create pod-operator-firewall \
 
 8. If you intend to migrate tables over to BQ dataset other than dmt-teradata-dataset, please ensure this dataset is manually created and is provided in the config files later  (create tables from DDLs)
 
-9.  **(Mandatory for teradata ddl extraction)** Teradata ddl extraction requires teradata jdbc jar. Upload the jdbc jar file to your GCS config bucket under the `software/teradata` folder as shown below:
+9.  **(Mandatory for Teradata DDL Extraction)** Teradata DDL extraction requires Teradata JDBC JAR. Upload the JDBC JAR file to your GCS config bucket under the `software/teradata` folder as shown below:
 
-      1) Download the jar from teradata downloads: 	[https://downloads.teradata.com/download/connectivity/jdbc-driver](https://downloads.teradata.com/download/connectivity/jdbc-driver)
+      1) Download the JAR from teradata downloads: 	[https://downloads.teradata.com/download/connectivity/jdbc-driver](https://downloads.teradata.com/download/connectivity/jdbc-driver)
 
-      2) Upload the jar to your GCS config bucket and ensure that the jar file name exactly matches `terajdbc4.jar`. \
+      2) Upload the JAR to your GCS config bucket and ensure that the file name is exactly `terajdbc4.jar`. \
       Make sure the file is placed in the `software/teradata` path \
       (e.g. `gs://YOUR_DMT_CONFIG_BUCKET/software/teradata/terajdbc4.jar`)
 

--- a/docs/installation/README_teradata_datamigration.md
+++ b/docs/installation/README_teradata_datamigration.md
@@ -87,17 +87,17 @@ _DATA_SOURCE=teradata
         sudo ./TeradataToolsAndUtilitiesBase/setup.sh 1 2 5 15
         ```
 
-* Copy teradata jdbc jar to Agent VM (dm-vm-teradata-bq) at path:  `/opt/migration_project_teradata_bq/`
-    1. Download the jar from teradata downloads (if you have not already done this in the main ReadMe setup): [https://downloads.teradata.com/download/connectivity/jdbc-driver](https://downloads.teradata.com/download/connectivity/jdbc-driver)
+* Copy Teradata JDBC JAR to Agent VM (dm-vm-teradata-bq) at path:  `/opt/migration_project_teradata_bq/`
+    1. If you have not already done this during the main ReadMe setup instructions, download the JAR from Teradata downloads: [https://downloads.teradata.com/download/connectivity/jdbc-driver](https://downloads.teradata.com/download/connectivity/jdbc-driver)
     2. Upload the package to a bucket (_&lt;temp-bucket>_)
     3. SSH into the Agent VM and switch user to root
-    4. Copy the teradata jdbc jar from _&lt;temp-bucket>_ to Agent VM (Make sure it is copied with name `terajdbc4.jar`)
+    4. Copy the Teradata JDBC JAR from _&lt;temp-bucket>_ to Agent VM (ensure it is named `terajdbc4.jar`)
         ```
         gsutil cp gs://<temp-bucket>/terajdbc4.jar /opt/migration_project_teradata_bq/
         ```
 
 
-* Ensure the teradata agent VM (Google Compute Engine) has the following folder structure which signifies successful deployment of executables in the Agent VM `/opt/migration_project_teradata_bq/`
+* Ensure the Teradata Agent VM (Google Compute Engine) has the following folder structure which signifies successful deployment of executables in the Agent VM `/opt/migration_project_teradata_bq/`
 
 ```
 > pwd

--- a/terraform/datamigration/teradata/gce/variables.tf
+++ b/terraform/datamigration/teradata/gce/variables.tf
@@ -53,7 +53,7 @@ variable "zone" {
 variable "machine_type" {
   type        = string
   description = "machine_type for compute engine instance"
-  default     = "n2-standard-32"
+  default     = "n2-standard-16"
 }
 variable "network" {
   type        = string

--- a/terraform/datamigration/teradata/gce/variables.tf
+++ b/terraform/datamigration/teradata/gce/variables.tf
@@ -53,7 +53,7 @@ variable "zone" {
 variable "machine_type" {
   type        = string
   description = "machine_type for compute engine instance"
-  default     = "n2-standard-2"
+  default     = "n2-standard-32"
 }
 variable "network" {
   type        = string
@@ -89,7 +89,7 @@ variable "disk_type" {
 variable "disk_size" {
   type        = number
   description = "attached disk size for data migration"
-  default     = 100
+  default     = 1000
 }
 variable "datamigration_teradata_script" {
   type        = string


### PR DESCRIPTION
1. Updates Terraform to increase the default Teradata Agent VM machine size and disk size. The current default is likely too small for a production migration of dozens/hundreds of TB. The new sizes ensure that network bandwidth and disk throughput are kept high ([GCE machine shape docs](https://cloud.google.com/compute/docs/general-purpose-machines#n2_machine_types), [GCE disk performance docs](https://cloud.google.com/compute/docs/disks/performance#n2_vms)).

2. Docs fixes mainly related the Shared VPC setup ([Composer Shared VPC docs](https://cloud.google.com/composer/docs/composer-2/configure-shared-vpc#permissions-composer-service-agent)).