### PR TITLE
Move Composer GKE pod firewall rule to Terraform

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TERRAFORM_VERSION=1.3.7
-TERRAGRUNT_VERSION=0.43.0
+TERRAFORM_VERSION=1.5.7-*
+TERRAGRUNT_VERSION=0.67.16
 
 #######################################
 # Installs Terraform according to website:

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -87,69 +87,36 @@ The DVT Cloud Run and Cloud Composer should only be created in the same region.
 
 Deployment of DMT through terraform modules is split into 2 parts
 
-
-
 * Translation – For DDL, DML, SQL translation and validation.
 * Data Migration - For data migration from different sources (Teradata and Hive)
 
-## Clone the DMT git repository
 
-The code repository is hosted on Github and can be cloned using below command.
+## Clone the DMT GitHub repository
 
+The code repository is hosted on Github. Clone it and check out the main branch using the commands below.
 
 ```
 git clone https://github.com/GoogleCloudPlatform/data-migration-tool
-```
-
-
-Navigate to clone directory using below command
-
-
-```
 cd data-migration-tool
-```
-
-Checkout the main branch using below command
-
-
-
-```
 git checkout main
 ```
 
+## Set project environment variables
+```
+export SOURCE_PROJECT=<YOUR_PROJECT_ID>
+```
 
-## Assign Executing User and Admin Permissions
+```
+gcloud config set project $SOURCE_PROJECT
+```
 
-Admin User who will be executing the deployment of DMT through Cloud Build will require the below set of permissions
+## Assign Admin and Executing User Permissions
 
-* roles/bigquery.dataViewer
-* roles/bigquery.user
-* roles/cloudbuild.builds.editor
-* roles/run.viewer
-* roles/compute.admin
-* roles/iam.serviceAccountViewer
-* roles/logging.viewer
-* roles/run.viewer
-* roles/serviceusage.serviceUsageConsumer
-* roles/storage.admin
-* roles/iam.serviceAccountViewer
-* projects/${PROJECT_ID}/roles/DMTAdminAdditionalPermissions
+There are two main personas for DMT - the Admin and the User. The Admin is responsible for managing DMT infrastructure (such as granting permissions to the Cloud Build service account which executes the Terraform deployment). The User is responsible for using DMT post-deployment for migration activities, such as triggering SQL translation or data validation.
 
+We provide scripts to assign the required permissions for each of these personas by a superadmin. This includes creating two custom roles with a limited set of granular permissions.
 
-And, user who will be using the DMT tool will require the below set of permissions
-
-* roles/bigquery.dataViewer
-* roles/bigquery.admin
-* roles/run.viewer
-* roles/composer.user
-* roles/storage.admin
-* roles/vpcaccess.admin
-* roles/logging.viewer
-* projects/${PROJECT_ID}/roles/DMTUserAdditionalPermissions
-
-
-**Note - DMTUserAdditionalPermissions role is custom DMT user role and DMTAdminAdditionalPermissions is also custom role for DMT admin**
-
+Set the following environment variables for the Admin and User, and then execute the provided bash scripts to create the custom roles and IAM permission bindings.
 
 ```
  export ADMIN_ACCOUNT=<EXECUTING_ADMIN_ACCOUNT>
@@ -160,49 +127,19 @@ And, user who will be using the DMT tool will require the below set of permissio
 ```
 
 ```
- export SOURCE_PROJECT=<YOUR_PROJECT_ID>
-```
-
-
-**DMT requires additional user/admin permission except predefined role, you can execute the Bash script dmt-user-custom-role-creation.sh and dmt-admin-custom-role-creation.sh present in the root directory to create custom dmt user/admin additional permission role**
-
-
-```
+bash dmt-admin-custom-role-creation.sh
 bash dmt-user-custom-role-creation.sh
 ```
 
-
 ```
-bash dmt-admin-custom-role-creation.sh
-```
-
-**To assign these roles, you can execute the Bash script dmt-user-iam-setup.sh and dmt-admin-user-iam-setup.sh present in the root directory**
-
-```
+bash dmt-admin-user-iam-setup.sh
 bash dmt-user-iam-setup.sh
 ```
 
 
-```
-bash dmt-admin-user-iam-setup.sh
-```
-
 ## Enable Google Cloud APIs
 
 From the Cloud Shell, you can enable Google Cloud Services using the gcloud command line interface in your Google Cloud project.
-
-
-```
-export SOURCE_PROJECT=<YOUR_PROJECT_ID>
-```
-
-
-
-```
-gcloud config set project $SOURCE_PROJECT
-```
-
-
 
 ```
 gcloud services enable serviceusage.googleapis.com \
@@ -252,7 +189,6 @@ Once the execution of the bash script is successful, you can proceed to the next
 Translations deployment will take care of the workflow needed to perform
 
 
-
 * DDL, DML and SQL translations
 * Schema migration to BQ (Creation of tables from translated DDLs)
 * Schema Validation and Custom query(row/column for SQL validation) using [DVT tool](https://github.com/GoogleCloudPlatform/professional-services-data-validator)
@@ -271,15 +207,6 @@ If you choose the deployment of Translation + Data Migration, in addition to the
 ### Pre deployment Steps
 
 #### 1. Before you proceed with DMT terraform deployment, ensure that there is a GCS bucket created to store Terraform infrastructure State Files
-
-```
-export SOURCE_PROJECT=<YOUR_PROJECT_ID>
-```
-
-
-```
-gcloud config set project ${SOURCE_PROJECT}
-```
 
 
 ```
@@ -329,11 +256,9 @@ Perform below predeployment steps to setup/configure shared VPC for composer -
    export HOST_PROJECT=<HOST_PROJECT_ID>
    ```
 
-
    ```
    export SOURCE_PROJECT=<YOUR_PROJECT_ID>
    ```
-
 
    2. Network resource configuration - VPC network should have subnetwork with the region available for cloud composer [see available regions list under Products available by location section](https://cloud.google.com/about/locations#regions) deployment. Subnetwork should have 2 Secondary IP ranges created explicitly which is required for GKE pods and services.
 
@@ -430,7 +355,7 @@ For more information and references please visit [Configure Shared VPC networkin
 
 
 
-1. Set default GCP project in your Cloud shell or terminal or bastion host with terraform, terragrunt and gcloud sdk installed
+1. Set default GCP project in your Cloud Shell or terminal or bastion host with Terraform, Terragrunt and gcloud SDK installed
 
 ```
 gcloud config set project ${SOURCE_PROJECT}

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -668,56 +668,14 @@ DONE
 
 **Follow the below steps for Teradata and Oracle**
 
-Check if the environment values still exist and are correct, if not, set them again for post-installation steps
 
-Ensure you have an existing source database environment for testing:
+1. Ensure you have an existing source database environment for testing, with network connectivity to the project's VPC:
 
 * For Teradata,
-   * If you do not have one,  you can create one [following the steps here](https://quickstarts.teradata.com/vantage.express.gcp.html).
-   * If you want to follow the qwiklab to set up TD instance with tpch installed when finished, you can [follow the steps here](https://gcpstaging.qwiklabs.com/catalog_lab/25971).
+   * If you do not have one, you can create one [following the steps here](https://quickstarts.teradata.com/vantage.express.gcp.html).
+   * If you want to follow the Qwiklab to set up TD instance with tpch installed when finished, you can [follow the steps here](https://gcpstaging.qwiklabs.com/catalog_lab/25971).
 * For Oracle,
    * If you do not have one,  you can create one [following the steps here](https://github.com/oracle/docker-images/tree/main/OracleDatabase/SingleInstance).
-
-Set environment variables in Cloud Shell
-
-
-```
-export SOURCE_PROJECT=<YOUR_PROJECT_ID>
-```
-
-
-**&lt;SOURCE_PROJECT>** -   Project ID where you will be deploying DMT tool
-
-
-
-1. Grant **Cloud Run invoker** role to PubSub service account (**dmt-sa-pubsub**) under GCP IAM roles.
-
-```
-gcloud projects add-iam-policy-binding $SOURCE_PROJECT \
---member="serviceAccount:dmt-sa-pubsub@$SOURCE_PROJECT.iam.gserviceaccount.com" \
---role="roles/run.invoker"
-```
-
-2. Go to the GCP console and search for Kubernetes Clusters - select your composer cluster instance and identify the IP subnet range of the Pod **_Address range_**.
-
-3. Go to your VPC network (default in this case) and create a firewall rule with the name **_pod-operator-firewall._**
-* Direction of Traffic - Ingress
-* Action on Match - Allow
-* Targets - All instances in the network [Teradata/Oracle GCE instance]
-* Source Filter - IPv4
-* Source IPv4 ranges - <Pod Address range> that you got in step #2. E.g: 10.57.0.0/17
-* Protocols and Ports - Allow all / Allowed Teradata ports
-
-```
-gcloud compute firewall-rules create pod-operator-firewall \
---project=$SOURCE_PROJECT \
---direction=INGRESS \
---priority=1000 \
---network=<YOUR Composer VPC name> \
---action=ALLOW \
---rules=all \
---source-ranges=<YOUR Composer Kubernetes Pod Cluster IP obtained from Step 2>
-```
 
 
 
@@ -726,28 +684,27 @@ gcloud compute firewall-rules create pod-operator-firewall \
    * [Teradata TCP DB connection port](https://docs.teradata.com/r/Teradata-Unity-Installation-Configuration-and-Upgrade-Guide-for-Customers/January-2018/Overview/Ports-Used-by-Unity)
    * [Oracle TCP DB connection port](https://docs.oracle.com/en/database/oracle/oracle-database/19/ladbi/oracle-database-component-port-numbers-and-protocols.html#GUID-B530F5CD-DD07-44D9-8499-0828B716C3A8)
 
-4. Go to Secret Manager and create a new secret with the name **secret-edw_credentials**
+
+   **<span style="text-decoration:underline;">Note</span>** (Real customer use cases): please create vpc access connectors as part of the VPC that has firewalls open to connect to customer’s on prem teradata instance. The Cloud Run service (to execute the DVT tool) requires the VPC access connector to be attached to it to hit the Teradata/Oracle DB.
+   * [Teradata TCP DB connection port](https://docs.teradata.com/r/Teradata-Unity-Installation-Configuration-and-Upgrade-Guide-for-Customers/January-2018/Overview/Ports-Used-by-Unity).
+   * [Oracle TCP DB connection port](https://docs.oracle.com/en/database/oracle/oracle-database/19/ladbi/oracle-database-component-port-numbers-and-protocols.html#GUID-B530F5CD-DD07-44D9-8499-0828B716C3A8).
+
+   **<span style="text-decoration:underline;">Note</span>** (_If you are a Googler_): _If you are a Googler and are running a test environment with Teradata Express edition or Oracle on GCP Compute VMs, ensure you add a network tag cc-dvt to the on TD/Oracle instance.
+
+
+2. Go to Secret Manager and create a new secret with the name **secret-edw_credentials**
 
     This should contain the password for Teradata/Oracle DB. It is recommended to keep the name of the secret as **secret-edw_credentials**
 
 
-**<span style="text-decoration:underline;">Note</span>** (Real customer use cases): please create vpc access connectors as part of the VPC that has firewalls open to connect to customer’s on prem teradata instance. The Cloud Run service (to execute the DVT tool) requires the VPC access connector to be attached to it to hit the Teradata/Oracle DB
-* [Teradata TCP DB connection port](https://docs.teradata.com/r/Teradata-Unity-Installation-Configuration-and-Upgrade-Guide-for-Customers/January-2018/Overview/Ports-Used-by-Unity).
-* [Oracle TCP DB connection port](https://docs.oracle.com/en/database/oracle/oracle-database/19/ladbi/oracle-database-component-port-numbers-and-protocols.html#GUID-B530F5CD-DD07-44D9-8499-0828B716C3A8).
+1. Validate if all DAG Airflows in the Cloud Composer instance are in paused state through Airflow URI
 
-**<span style="text-decoration:underline;">Note</span>** (_If you are a Googler_): _If you are a Googler and are running a test environment with Teradata express edition or Oracle on GCP Compute VMs, ensure you add a network tag cc-dvt to the on TD/Oracle instance_
+2. Switch all the DAG status to Active
 
-
-
-5. Validate if all DAG Airflows in the Cloud Composer instance are in paused state through Airflow URI
-
-6. Switch all the DAG status to Active
-
-7. Validate **workload_identity_creator_dag in Airflow UI** is executed one time automatically on turning DAGs active and is successful
+3. Validate **workload_identity_creator_dag in Airflow UI** is executed one time automatically on turning DAGs active and is successful
 
 
 ![alt_text](images/workload_identity.png "image_tooltip")
-
 
 
 
@@ -766,6 +723,12 @@ gcloud compute firewall-rules create pod-operator-firewall \
 
 **Build connection between CloudRun and Source database [Applicable for network connectivity uses VPN connectivity]**
 
+1. Set environment variable in Cloud Shell:
+
+```
+export SOURCE_PROJECT=<YOUR_DMT_PROJECT_ID>
+```
+
 1. Create serverless VPC Connector (specify same network as well as region which has firewall rules allowed to connect to on prem/ cloud data source)
 
 ```
@@ -779,9 +742,7 @@ gcloud compute networks vpc-access connectors create crun-dvt-connector \
 --machine-type f1-micro
 ```
 
-
 2. Attach the network tag **cc-dvt** as the target or provide directly the IP address of the on prem TD/Oracle instance. (This tag can be used as target tag while creating a firewall rule at a later stage)
-
 
 3. Create an ingress firewall rule (in source database network) to deny traffic from connector network tag:
 
@@ -789,38 +750,22 @@ gcloud compute networks vpc-access connectors create crun-dvt-connector \
 gcloud compute firewall-rules create deny-vpc-connector --action=DENY --rules=all --source-tags=vpc-connector-us-central1-crun-dvt-connector --direction=INGRESS --network=default --priority=990
 ```
 
-
 4. Create an ingress firewall rule targeting the Teradata/Oracle IP that you want the VPC connector to access. Set the priority for this rule to be a lower value than the priority of the rule you made in Step 25. (Here **cc-dvt **is the network tag attached to Teradata/Oracle VM)
 
 ```
 gcloud compute firewall-rules create allow-vpc-connector-for-select-resources --allow=all --source-tags=vpc-connector-us-central1-crun-dvt-connector --direction=INGRESS --network=default --target-tags=cc-dvt --priority=980
 ```
 
-
 5. Deploy a new version of the Cloud Run DVT service ([edw-dvt-tool-](https://console.cloud.google.com/run/detail/us-central1/edw-dvt-tool-control?project=dmt-test-12)&lt;customerid>) after performing the below changes
     1. Setting the connector
     ![alt_text](images/vpc_connector.png "image_tooltip")
-    2. Go to the Secrets section in the Cloud Run and configure as shown below
+    2. Go to the Secrets section in Cloud Run and configure as shown below:
+         - Secret: **secret-edw_credentials**
+         - Reference Method **:  Exposed as Environment variable**
+         - Environment_variables
+           - Name 1: **edw_credentials**
 
-   Secret: **secret-edw_credentials**
-
-
-
-   Reference Method **:  Exposed as Environment variable**
-
-
-   Environment_variables
-
-
-   Name 1: **edw_credentials**
-
-
-
-![alt_text](images/secret_manager.png "image_tooltip")
-
-
-
-
+         ![alt_text](images/secret_manager.png "image_tooltip")
 
 
 
@@ -847,12 +792,9 @@ gcloud compute firewall-rules create allow-vpc-connector-for-select-resources --
 
     For example,
 
-
     **DDL** = gs://dmt-config-control/input/ddl
 
-
     **SQL** = gs://dmt-config-control/input/sql
-
 
     **DML** = gs://dmt-config-control/input/dml
 

--- a/src/translation/dvt/requirements.txt
+++ b/src/translation/dvt/requirements.txt
@@ -1,7 +1,7 @@
 Flask
 gunicorn
 Werkzeug
-google-pso-data-validator==4.2.0
+google-pso-data-validator==6.3.0
 google-cloud-secret-manager
 hdfs
 thrift-sasl

--- a/src/translation/scripts/teradata/extract_teradata_ddls.sh
+++ b/src/translation/scripts/teradata/extract_teradata_ddls.sh
@@ -17,14 +17,14 @@ SOURCE_DB=$3
 FOLDER_NAME=$4
 
 # DWH Library version
-DWH_LIB_VERSION="1.0.13"
+DWH_LIB_VERSION="1.0.62"
 
 # Check if dwh lib folder is not found, unzip directory
-if [ ! -d "$WORK_DIR/dwh-migration-tools-v$DWH_LIB_VERSION" ]; 
+if [ ! -d "$WORK_DIR/dwh-migration-tools-v$DWH_LIB_VERSION" ];
 then
     echo "$WORK_DIR/dwh-migration-tools-v$DWH_LIB_VERSION not found"
-    
-    cd $WORK_DIR 
+
+    cd $WORK_DIR
 
     echo "Download dwh-migration-tools-v$DWH_LIB_VERSION.zip"
     wget https://github.com/google/dwh-migration-tools/releases/download/v$DWH_LIB_VERSION/dwh-migration-tools-v$DWH_LIB_VERSION.zip
@@ -56,16 +56,16 @@ echo "Execute dwh dumper to generate metadata"
 
 # Check file is exist or not
 outputFile=dwh-migration-${SOURCE_DB}-metadata.zip
-if test -f "$outputFile"; 
+if test -f "$outputFile";
 then
     echo "$outputFile is generated."
     # Unzip generated folder
     unzip dwh-migration-${SOURCE_DB}-metadata.zip -d dwh-migration-${SOURCE_DB}-metadata
-    
+
     # Copy metadata to composer bucket data folder
     mkdir -p $DATA_FOLDER_PATH/$FOLDER_NAME
     cp -R dwh-migration-${SOURCE_DB}-metadata/* $DATA_FOLDER_PATH/$FOLDER_NAME
-    
+
     # Remove generated zip from working directory
     rm dwh-migration-${SOURCE_DB}-metadata.zip
     rm -r dwh-migration-${SOURCE_DB}-metadata

--- a/terraform/datamigration/hive/bq_inc/main.tf
+++ b/terraform/datamigration/hive/bq_inc/main.tf
@@ -59,10 +59,11 @@ resource "google_pubsub_subscription" "hive_incremental_sub" {
   ack_deadline_seconds = 600
 
   bigquery_config {
-
     table          = "${var.project_id}:${var.logging_dataset}.${var.hive_inc_load_pubsub_audit}"
     write_metadata = true
-
+  }
+  expiration_policy {
+    ttl = ""
   }
 
 }

--- a/terraform/datamigration/redshift/cloudrun/main.tf
+++ b/terraform/datamigration/redshift/cloudrun/main.tf
@@ -6,7 +6,7 @@
  */
 
 /*********************************************
-Cloud Run updates for data migration topics                                               
+Cloud Run updates for data migration topics
 **********************************************/
 
 /* Retrieve Cloud run API endpoint URL */
@@ -53,6 +53,9 @@ resource "google_pubsub_subscription" "push_subscribe" {
     attributes = {
       x-goog-version = "v1"
     }
+  }
+  expiration_policy {
+    ttl = ""
   }
   enable_message_ordering = true
 }

--- a/terraform/datamigration/teradata/cloudrun/main.tf
+++ b/terraform/datamigration/teradata/cloudrun/main.tf
@@ -6,7 +6,7 @@
  */
 
 /*********************************************
-Cloud Run updates for data migration topics                                               
+Cloud Run updates for data migration topics
 **********************************************/
 
 /* Retrieve Cloud run API endpoint URL */
@@ -52,6 +52,9 @@ resource "google_pubsub_subscription" "push_subscribe" {
     attributes = {
       x-goog-version = "v1"
     }
+  }
+  expiration_policy {
+    ttl = ""
   }
   enable_message_ordering = true
 }

--- a/terraform/datamigration/teradata/gce/variables.tf
+++ b/terraform/datamigration/teradata/gce/variables.tf
@@ -68,7 +68,8 @@ variable "subnetwork" {
 variable "image" {
   type        = string
   description = "image of compute engine instance"
-  default     = "ubuntu-minimal-2204-jammy-v20220902"
+  default     = "family/ubuntu-minimal-2204-lts"
+  # Can pin to a specific version, eg. "ubuntu-minimal-2204-jammy-v20240926"
 }
 variable "boot_size" {
   type        = number

--- a/terraform/datamigration/teradata/pubsub/main.tf
+++ b/terraform/datamigration/teradata/pubsub/main.tf
@@ -6,7 +6,7 @@
  */
 
 /******************************************
- Pub Sub topics notification                                                   
+ Pub Sub topics notification
 *****************************************/
 
 data "google_storage_project_service_account" "gcs_account" {
@@ -40,7 +40,7 @@ resource "google_pubsub_subscription" "dmt_dts_controller_subscription" {
   retain_acked_messages      = true
   ack_deadline_seconds       = 60
   expiration_policy {
-    ttl = "300000.5s"
+    ttl = ""
   }
   retry_policy {
     minimum_backoff = "10s"

--- a/terraform/translation/cloudrun/main.tf
+++ b/terraform/translation/cloudrun/main.tf
@@ -6,7 +6,7 @@
  */
 
 /*********************************************
- Eventarc setup with Cloud Run as destination                                                 
+ Eventarc setup with Cloud Run as destination
 **********************************************/
 
 /* Retrieve Composer API endpoint URL */
@@ -173,6 +173,9 @@ resource "google_pubsub_subscription" "push_subscribe" {
     attributes = {
       x-goog-version = "v1"
     }
+  }
+  expiration_policy {
+    ttl = ""
   }
   enable_message_ordering = true
 }

--- a/terraform/translation/gcc/main.tf
+++ b/terraform/translation/gcc/main.tf
@@ -263,3 +263,24 @@ resource "null_resource" "upload_common_utils" {
     command = "gsutil -o \"GSUtil:parallel_process_count=1\" -m cp -r ${var.common_utils} ${google_composer_environment.composer_env.config.0.dag_gcs_prefix}/"
   }
 }
+
+
+/* Set up firewall rule to allow Composer GKE cluster pods (KubernetesPodOperator) to reach the rest of the VPC network. */
+
+data "google_container_cluster" "composer_gke_cluster" {
+  name     = split("/", data.google_composer_environment.composer_env.config.0.gke_cluster)[5]
+  location = split("/", data.google_composer_environment.composer_env.config.0.gke_cluster)[3]
+}
+
+resource "google_compute_firewall" "dmt-pod-operator" {
+  name        = "dmt-allow-composer-gke-pods"
+  network     = data.google_composer_environment.composer_env.config.0.node_config.0.network
+  description = "Allows Composer cluster GKE pods to reach the default VPC range."
+
+  priority      = 1001
+  direction     = "INGRESS"
+  source_ranges = [data.google_container_cluster.composer_gke_cluster.ip_allocation_policy.0.cluster_ipv4_cidr_block]
+  allow {
+    protocol = "all"
+  }
+}

--- a/terraform/translation/gcc/variables.tf
+++ b/terraform/translation/gcc/variables.tf
@@ -25,8 +25,8 @@ variable "location" {
 }
 variable "image_version" {
   type        = string
-  description = "The version of the aiflow running in the cloud composer environment."
-  default     = "composer-2.4.6-airflow-2.5.3"
+  description = "The version of the Airflow running in the cloud composer environment."
+  default     = "composer-2-airflow-2"
 }
 variable "service_account_gcc" {
   type        = string


### PR DESCRIPTION
Adds Terraform for a firewall rule to allow the Composer GKE cluster pod IP range to reach the VPC network, allowing Kubernetes pod operator to run (eg. for DVT validation runs). 

Removes instructions for setting this up manually from the installation ReadMe. Also removes steps for adding the Cloud Run Invoker role from the ReadMe since that's already granted in TF.