### PR TITLE
Add config validation and normalize secret prefix

### DIFF
--- a/cloudbuild-sa-iam-setup.sh
+++ b/cloudbuild-sa-iam-setup.sh
@@ -34,6 +34,7 @@ roles=(
   "roles/composer.admin"
   "roles/compute.instanceAdmin.v1"
   "roles/compute.networkAdmin"
+  "roles/container.viewer"
   "roles/iam.serviceAccountCreator"
   "roles/iam.serviceAccountUser"
   "roles/iam.serviceAccountDeleter"

--- a/cloudbuild-sa-iam-setup.sh
+++ b/cloudbuild-sa-iam-setup.sh
@@ -34,6 +34,7 @@ roles=(
   "roles/composer.admin"
   "roles/compute.instanceAdmin.v1"
   "roles/compute.networkAdmin"
+  "roles/compute.securityAdmin"
   "roles/container.viewer"
   "roles/iam.serviceAccountCreator"
   "roles/iam.serviceAccountUser"

--- a/cloudbuild-sa-iam-setup.sh
+++ b/cloudbuild-sa-iam-setup.sh
@@ -30,6 +30,7 @@ gcloud services enable \
 roles=(
   "roles/artifactregistry.admin"
   "roles/bigquery.admin"
+  "roles/cloudbuild.builds.builder"
   "roles/composer.admin"
   "roles/compute.instanceAdmin.v1"
   "roles/compute.networkAdmin"
@@ -37,6 +38,7 @@ roles=(
   "roles/iam.serviceAccountUser"
   "roles/iam.serviceAccountDeleter"
   "roles/logging.viewer"
+  "roles/logging.logWriter"
   "roles/pubsub.admin"
   "roles/resourcemanager.projectIamAdmin"
   "roles/run.admin"

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -1006,9 +1006,9 @@ Source datawarehouse : Teradata
    </td>
    <td>Secret Manager key name
 <p>
-<strong>secret: &lt;secret key name></strong>
+<strong>secret- &lt;secret key name></strong>
 <p>
-For example - secret:edw_credentials
+For example - secret-edw_credentials
    </td>
   </tr>
   <tr>
@@ -1239,9 +1239,9 @@ Source datawarehouse : Teradata
    </td>
    <td>Secret Manager key name
 <p>
-<strong>secret: &lt;secret key name></strong>
+<strong>secret- &lt;secret key name></strong>
 <p>
-For example - secret:edw_credentials
+For example - secret-edw_credentials
    </td>
   </tr>
   <tr>

--- a/docs/installation/README_redshift_datamigration.md
+++ b/docs/installation/README_redshift_datamigration.md
@@ -4,7 +4,7 @@
 
 ### Tool Features
 
-* Initial release will support bulk load data transfer only. 
+* Initial release will support bulk load data transfer only.
 * Initial release will support Redshift to BigQuery translation using BQ DTS, row and column validation of the data in source and target.
 
 ### Things to Take Note of
@@ -21,10 +21,10 @@
 
 The user uploads a configuration json file to **dmt-config-&lt;customer_name provided in TF>**  bucket **data** folder which initiates data migration.
 
-As the configuration is uploaded, a new file create/update trigger is sent to pub/sub which triggers the DAG **controller_dag** via cloudrun. 
+As the configuration is uploaded, a new file create/update trigger is sent to pub/sub which triggers the DAG **controller_dag** via cloudrun.
 This DAG is responsible for triggering relevant schema/data migration dag based on operation type and data source given in user config, For redshit data migrationm it'll trigger  **redshift_data_load_dag** which is responsible for parallelizing the data transfer config creation, based on the user defined key - _batchDistribution_.
 
-### Prerequisites 
+### Prerequisites
 
 * Target dataset creation to be done by the user/concerned team before uploading the configuration file.
 * If your redshift cluster is **private**
@@ -99,9 +99,9 @@ The below list of logging tables are created by terraform templates and record a
   </tr>
 </table>
 
-## Trigger Data Migration Tool 
+## Trigger Data Migration Tool
 
-* Data Migration 
+* Data Migration
 * Data Validations
 * SQL Validations
 
@@ -120,9 +120,9 @@ The below list of logging tables are created by terraform templates and record a
        "params": {
            "jdbc_url": "jdbc:redshift://<host>.<region>.redshift.amazonaws.com:5439/dev",
            "database_username": "<username>",
-           "database_password": "secret:<redshift_secret_name>",
+           "database_password": "secret-<redshift_secret_name>",
            "access_key_id": "<aws_access_key_id>",
-           "secret_access_key": "secret:<aws_access_key>",
+           "secret_access_key": "secret-<aws_access_key>",
            "s3_bucket": "s3://<bucketname>/",
            "redshift_schema": "<redshift_schema_name>",
            "migration_infra_cidr": "<vpc>:<10.0.0.0/24(use this variable only when your Redshift cluster is private. If its public remove this line)>"
@@ -139,7 +139,7 @@ The below list of logging tables are created by terraform templates and record a
            "host": "<host>.<region>.redshift.amazonaws.com",
            "port": "5439",
            "user-name": "<source_db_username>",
-           "password": "secret:<redshift_secret_name>"
+           "password": "secret-<redshift_secret_name>"
        },
        "target_config": {
            "target_type": "BigQuery",
@@ -243,7 +243,7 @@ The below list of logging tables are created by terraform templates and record a
   <tr>
     <td> transfer_config:params:migration_infra_cidr </td>
     <td> <strong>Optional</strong>: Use this key if your redhsift cluster is not public and you have configured VPN to a VPC network in your GCP project</br>
-      Specify VPC network name and the private IP address range to use in the tenant project VPC network. Specify the IP address range as a CIDR block. 
+      Specify VPC network name and the private IP address range to use in the tenant project VPC network. Specify the IP address range as a CIDR block.
       <ul>
          <li>The form is VPC_network_name:CIDR, for example: my_vpc:10.251.1.0/24.</li>
          <li>Use standard private VPC network address ranges in the CIDR notation, starting with 10.x.x.x.</li>
@@ -275,8 +275,8 @@ The below list of logging tables are created by terraform templates and record a
   <tr>
     <td> validation_config:source_config:password </td>
     <td>Secret Manager key name <p> (Secret should be created in the Secret Manager as _secret-&lt;secret-key-name>_.)
-        <strong>secret: &lt;secret key name></strong>
-      <p> For example - secret:edw_credentials
+        <strong>secret- &lt;secret key name></strong>
+      <p> For example - secret-edw_credentials
     </td>
   </tr>
   <tr>
@@ -294,11 +294,11 @@ The below list of logging tables are created by terraform templates and record a
    <td>GCS location of the CSV file or Excel sheet, containing table or file names along with DVT Validation Flags.
    <p>
    Examples:
-   
+
    gs://dmt-config-dmt-demo-project/validation/teradata/validation_params.csv
 
    gs://dmt-config-dmt-demo-project/validation/teradata/validation_params.xlsx
-   
+
 <strong><em>Read [Instructions](#instructions-to-populate-and-upload-validation-paramaters-file) below to understand how to populate and upload this file/sheet</em></strong>
    </td>
   </tr>
@@ -321,7 +321,7 @@ The below list of logging tables are created by terraform templates and record a
 </table>
 
 
-**unique_id:** name to uniquely identify the batches or DTS for this config file. 
+**unique_id:** name to uniquely identify the batches or DTS for this config file.
 
 _<span style="text-decoration:underline;">Note</span>_ if the user opted for data migration, along with schema migration through the tool, this unique id should be the same as the one used in the schema migration config file.
 
@@ -329,17 +329,17 @@ _<span style="text-decoration:underline;">Note</span>_ if the user opted for dat
 
 **notificationPubsubTopic:** field necessary to continue flow from Data Transfer Run Logging, including data validation. Given in the format _projects/&lt;project-name>/topics/edw-dts-notification-topic-**<customer_name provided in TF>.** Use the same topic as mentioned above, as required mappings are already done for this topic using the Foundations deployment.
 
-**destinationDatasetId:** Target dataset id for the particular schema migrated from redshift. 
+**destinationDatasetId:** Target dataset id for the particular schema migrated from redshift.
 
-**table_list_file:** file uploaded in GCS bucket same as the one used for uploading config file. This file should provide table names to be migrated from a particular schema in newlines. 
-Eg: 
+**table_list_file:** file uploaded in GCS bucket same as the one used for uploading config file. This file should provide table names to be migrated from a particular schema in newlines.
+Eg:
 - DEPARTMENT
 - EMPLOYEE
 - SALARY
 - HR_RECORDS
 
 
-<span style="text-decoration:underline;">Note</span> that this key only needs to be provided in case the user chooses to opt only for data migration through the tool (without schema translation). As such, tables structure is created by Bigquery DTS itself rather than the CompilerWorks schema migration feature from the tool. 
+<span style="text-decoration:underline;">Note</span> that this key only needs to be provided in case the user chooses to opt only for data migration through the tool (without schema translation). As such, tables structure is created by Bigquery DTS itself rather than the CompilerWorks schema migration feature from the tool.
 
 **_Tables in the CSV file should always be in the same case as how they exist in source Redshift and ultimately match the contents of CSV/Excel file uploaded as validation parameters file in GCS._**
 
@@ -355,7 +355,7 @@ Eg:
 
 **primary_key:** If validation_type is _row, _please provide another key called **primary_key** in the same section with the primary key for the particular table.
 
-Refer [REST Resource: projects.locations.transferConfigs | BigQuery | Google Cloud](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/v1/projects.locations.transferConfigs#TransferConfig) for exhaustive keys under transfer_config sub json. 
+Refer [REST Resource: projects.locations.transferConfigs | BigQuery | Google Cloud](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/v1/projects.locations.transferConfigs#TransferConfig) for exhaustive keys under transfer_config sub json.
 
 ## Instructions To Populate And Upload Validation Paramaters File
 
@@ -364,12 +364,12 @@ Refer [REST Resource: projects.locations.transferConfigs | BigQuery | Google Clo
    <br><strong>
    Fill the columns according to the use-case. Data Validation Rules within the sheet will help to fill the fields correctly.
    To know more about which flags are relevant for which translation (ddl,sql,custom-query) and migration (data), please refer to the tab named `DVT Guide`. This sheet contains link to DVT Github pages which explain about all possible flags in DVT CLI.
-   
+
    You can refer to the tab `Example Sheet` to get an idea of which flags can be supplied for which validation. </strong>
 * To follow along with Excel sheet
    * Open this [Excel Template File](/samples/validation_params_files/validation_params.xltx) in Microsoft Excel. (not in Google Sheets, as opening .xlsx in Google Sheets will corrupt the existing Data Validation Rules)
    * Fill the sheet `Validation` . Once filled, save the file in `.xlsx` format. (Excel will convert the template file format `.xltx` to `.xlsx` file for you)
-  
+
   <br>
  * To follow along with CSV file format
    * Open this <a href="https://docs.google.com/spreadsheets/d/1pNgvx23sBORssZj0de7mWgB8quYw6iCXngY_giijZhk/edit#gid=0">Google Sheet</a> in browser (Viewer Access).

--- a/docs/installation/README_teradata_datamigration.md
+++ b/docs/installation/README_teradata_datamigration.md
@@ -220,7 +220,7 @@ The below list of logging tables are created by terraform templates and record a
              "host": "<source_db_host_or_ip>",
              "port": 1025,
              "user-name": "<source_db_username>",
-             "password": "secret:<teradata_secret_name>"
+             "password": "secret-<teradata_secret_name>"
          },
          "target_config": {
              "target_type": "BigQuery",
@@ -564,9 +564,9 @@ Source datawarehouse : Teradata
    </td>
    <td>Secret Manager key name
 <p>
-<strong>secret: &lt;secret key name></strong>
+<strong>secret- &lt;secret key name></strong>
 <p>
-For example - secret:edw_credentials
+For example - secret-edw_credentials
    </td>
   </tr>
   <tr>
@@ -665,7 +665,7 @@ Eg:
 
 **location:** same as data location for the dataset
 
-**teradata-config:** contains host, user and password keys for the teradata server. Provide password value as _secret:&lt;secret-name-suffix>_. This secret should be created in the Secret Manager as _secret-&lt;secret-name-suffix>_.
+**teradata-config:** contains host, user and password keys for the teradata server. Provide password value as _secret-&lt;secret-name-suffix>_. This secret should be created in the Secret Manager as _secret-&lt;secret-name-suffix>_.
 
 <span style="text-decoration:underline;">Note</span> that target table name case is sensitive due to case sensitive nature of bigquery. So in the case of only Data Migration, it needs to be always be in the same case as how they exist in source Teradata and ultimately match with validation_config source_target_table mapping in config.json for DVT validations
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,10 +26,10 @@ import os
 import nox
 
 # Python version used for linting.
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.9"
 
 # Python versions used for testing.
-PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+PYTHON_VERSIONS = ["3.9", "3.10"]
 
 LINT_PACKAGES = ["flake8", "black==22.3.0", "isort"]
 

--- a/samples/configs/oracle/sampleconfig_for_ddl_sql_oracle.json
+++ b/samples/configs/oracle/sampleconfig_for_ddl_sql_oracle.json
@@ -79,16 +79,16 @@
             "port": 1521,
             "user": "<source_db_username>",
             "database": "<source_db_name>",
-            "password": "secret:<secret_name>"
+            "password": "secret-<secret_name>"
         },
         "target_config": {
             "source_type": "BigQuery",
             "project-id": "<project_id>"
         },
-        "validation_params_file_path" : "gs://<dmt-redshift-config-<project-id-or-customer-name-given-in-deployment>/validation/oracle/validation_params.csv",
+        "validation_params_file_path": "gs://<dmt-redshift-config-<project-id-or-customer-name-given-in-deployment>/validation/oracle/validation_params.csv",
         "validation_type": "schema",
         "validation_mode": "<gke/cloudrun>",
-        "pod_operator_mem" :"4000M",
-        "pod_operator_cpu" :"800m"
+        "pod_operator_mem": "4000M",
+        "pod_operator_cpu": "800m"
     }
 }

--- a/samples/configs/redshift/sampleconfig_for_data_migration_redshift.json
+++ b/samples/configs/redshift/sampleconfig_for_data_migration_redshift.json
@@ -1,47 +1,47 @@
 {
-    "unique_id":"unique_id_to_filter_bq_result_table",
-   "batchDistribution": 1,
-   "type": "data",
-   "source": "redshift",
-   "table_list_file": "gs://dmt-redshift-data-<project-id-or-customer-name-given-in-deployment>/tables_list.csv",
-   "transfer_config": {
-       "dataSourceId": "redshift",
-       "displayName": "unique_id_to_filter_bq_result_table",
-       "params": {
-           "jdbc_url": "jdbc:redshift://<host>.<region>.redshift.amazonaws.com:5439/dev",
-           "database_username": "<source_db_username>",
-           "database_password": "secret:<redshift_secret_name>",
-           "access_key_id": "<aws_access_key_id>",
-           "secret_access_key": "secret:<aws_access_key>",
-           "s3_bucket": "s3://<bucketname>/",
-           "redshift_schema": "<redshift_schema_name>",
-           "migration_infra_cidr": "<vpc>:<10.0.0.0/24(use this variable only when your Redshift cluster is private. If its public remove this line)>"
-       },
-       "emailPreferences": {
-           "enableFailureEmail": false
-       },
-       "notificationPubsubTopic": "projects/<project-id>/topics/dmt-redshift-dts-notification-topic-<project-id-or-customer-name-given-in-deployment>",
-       "destinationDatasetId": "<bq_target_dataset>"
-   },
-   "validation_config": {
-       "source_config": {
-           "source_type": "Redshift",
-           "host": "<host>.<region>.redshift.amazonaws.com",
-           "port": "5439",
-           "user": "<source_db_username>",
-           "database": "<source_db_name>",
-           "password": "secret:<redshift_secret_name>"
-       },
-       "target_config": {
-           "target_type": "BigQuery",
-           "project-id": "<project-id>"
-       },
-       "source_target_schema_table": [
+    "unique_id": "unique_id_to_filter_bq_result_table",
+    "batchDistribution": 1,
+    "type": "data",
+    "source": "redshift",
+    "table_list_file": "gs://dmt-redshift-data-<project-id-or-customer-name-given-in-deployment>/tables_list.csv",
+    "transfer_config": {
+        "dataSourceId": "redshift",
+        "displayName": "unique_id_to_filter_bq_result_table",
+        "params": {
+            "jdbc_url": "jdbc:redshift://<host>.<region>.redshift.amazonaws.com:5439/dev",
+            "database_username": "<source_db_username>",
+            "database_password": "secret-<redshift_secret_name>",
+            "access_key_id": "<aws_access_key_id>",
+            "secret_access_key": "secret-<aws_access_key>",
+            "s3_bucket": "s3://<bucketname>/",
+            "redshift_schema": "<redshift_schema_name>",
+            "migration_infra_cidr": "<vpc>:<10.0.0.0/24(use this variable only when your Redshift cluster is private. If its public remove this line)>"
+        },
+        "emailPreferences": {
+            "enableFailureEmail": false
+        },
+        "notificationPubsubTopic": "projects/<project-id>/topics/dmt-redshift-dts-notification-topic-<project-id-or-customer-name-given-in-deployment>",
+        "destinationDatasetId": "<bq_target_dataset>"
+    },
+    "validation_config": {
+        "source_config": {
+            "source_type": "Redshift",
+            "host": "<host>.<region>.redshift.amazonaws.com",
+            "port": "5439",
+            "user": "<source_db_username>",
+            "database": "<source_db_name>",
+            "password": "secret-<redshift_secret_name>"
+        },
+        "target_config": {
+            "target_type": "BigQuery",
+            "project-id": "<project-id>"
+        },
+        "source_target_schema_table": [
             "<source_db_username>.<table_name>=<bq_target_dataset>"
-       ],
-       "validation_mode": "<gke/cloudrun>",
-       "validation_type": "<row/column>",
-       "pod_operator_mem" :"4000M",
-       "pod_operator_cpu" :"800m"
-   }
+        ],
+        "validation_mode": "<gke/cloudrun>",
+        "validation_type": "<row/column>",
+        "pod_operator_mem": "4000M",
+        "pod_operator_cpu": "800m"
+    }
 }

--- a/samples/configs/redshift/sampleconfig_for_ddl_sql_redshift.json
+++ b/samples/configs/redshift/sampleconfig_for_ddl_sql_redshift.json
@@ -61,11 +61,11 @@
                         "source": {
                             "type": "SCHEMA",
                             "database": "<project_id>",
-                            "schema" : "<source_db_schema>"
+                            "schema": "<source_db_schema>"
                         },
                         "target": {
                             "database": "<project_id>",
-                            "schema" : "<bq_target_dataset>"
+                            "schema": "<bq_target_dataset>"
                         }
                     }
                 ]
@@ -79,16 +79,16 @@
             "port": 5439,
             "user": "<source_db_username>",
             "database": "<source_db_name>",
-            "password": "secret:<secret_name>"
+            "password": "secret-<secret_name>"
         },
         "target_config": {
             "source_type": "BigQuery",
             "project-id": "<project_id>"
         },
-        "validation_params_file_path" : "gs://<dmt-redshift-config-<project-id-or-customer-name-given-in-deployment>/validation/redshift/validation_params.csv",
+        "validation_params_file_path": "gs://<dmt-redshift-config-<project-id-or-customer-name-given-in-deployment>/validation/redshift/validation_params.csv",
         "validation_type": "schema",
-        "validation_mode":"<gke/cloudrun>",
-        "pod_operator_mem" :"4000M",
-        "pod_operator_cpu" :"800m"
+        "validation_mode": "<gke/cloudrun>",
+        "pod_operator_mem": "4000M",
+        "pod_operator_cpu": "800m"
     }
 }

--- a/samples/configs/teradata/sampleconfig_for_data_migration_teradata.json
+++ b/samples/configs/teradata/sampleconfig_for_data_migration_teradata.json
@@ -1,67 +1,67 @@
 {
-    "unique_id":"unique_id_to_filter_bq_result_table",
-    "batchDistribution":1,
-    "type":"data",
-    "source":"teradata",
-    "table_list_file": "gs://dmt-teradata-data-<project-id-or-customer-name-given-in-deployment>/tables_list.csv",
-    "transfer_config":{
-        "dataSourceId":"on_premises",
-        "displayName":"unique_id_to_filter_bq_result_table",
-        "params":{
-           "database_type":"Teradata",
-           "bucket":"dmt-teradata-data-<project-id-or-customer-name-given-in-deployment>",
-           "database_name":"<database_name>",
-           "agent_service_account":"dmt-teradata-agent-vm@<project-id>.iam.gserviceaccount.com"
-        },
-        "emailPreferences":{
-           "enableFailureEmail":false
-        },
-        "notificationPubsubTopic": "projects/<project-id>/topics/dmt-teradata-dts-notification-topic-<project-id-or-customer-name-given-in-deployment>",
-        "destinationDatasetId":"<bq_target_dataset>"
-     },
-     "agent_config":{
-        "transfer-configuration":{
-           "project-id":"<project-id>",
-           "location":"us"
-        },
-        "source-type":"teradata",
-        "console-log":false,
-        "silent":false,
-        "teradata-config":{
-           "connection":{
-               "host":"<source_db_host_or_ip>",
-               "username": "<source_db_username>",
-               "secret_resource_id": "projects/<project-id>/secrets/secret-edw_credentials/versions/<version_no>"
-           },
-           "local-processing-space":"/opt/migration_project_teradata_bq/local_processing_space",
-           "max-local-storage":"200GB",
-           "gcs-upload-chunk-size":"32MB",
-           "use-tpt":true,
-           "retain-tpt-files":false,
-           "max-sessions":0,
-           "spool-mode":"NoSpool",
-           "max-parallel-upload":2,
-           "max-parallel-extract-threads":2,
-           "session-charset":"UTF8",
-           "max-unload-file-size":"2GB"
-        }
-     },
-     "validation_config": {
-         "source_config": {
-             "source_type": "Teradata",
-             "host": "<source_db_host_or_ip>",
-             "port": 1025,
-             "user-name": "<source_db_username>",
-             "password": "secret:<teradata_secret_name>"
+   "unique_id": "unique_id_to_filter_bq_result_table",
+   "batchDistribution": 1,
+   "type": "data",
+   "source": "teradata",
+   "table_list_file": "gs://dmt-teradata-data-<project-id-or-customer-name-given-in-deployment>/tables_list.csv",
+   "transfer_config": {
+      "dataSourceId": "on_premises",
+      "displayName": "unique_id_to_filter_bq_result_table",
+      "params": {
+         "database_type": "Teradata",
+         "bucket": "dmt-teradata-data-<project-id-or-customer-name-given-in-deployment>",
+         "database_name": "<database_name>",
+         "agent_service_account": "dmt-teradata-agent-vm@<project-id>.iam.gserviceaccount.com"
+      },
+      "emailPreferences": {
+         "enableFailureEmail": false
+      },
+      "notificationPubsubTopic": "projects/<project-id>/topics/dmt-teradata-dts-notification-topic-<project-id-or-customer-name-given-in-deployment>",
+      "destinationDatasetId": "<bq_target_dataset>"
+   },
+   "agent_config": {
+      "transfer-configuration": {
+         "project-id": "<project-id>",
+         "location": "us"
+      },
+      "source-type": "teradata",
+      "console-log": false,
+      "silent": false,
+      "teradata-config": {
+         "connection": {
+            "host": "<source_db_host_or_ip>",
+            "username": "<source_db_username>",
+            "secret_resource_id": "projects/<project-id>/secrets/secret-edw_credentials/versions/<version_no>"
          },
-         "target_config": {
-             "target_type": "BigQuery",
-             "project-id": "<project-id>"
-         },
-         "validation_params_file_path" : "gs://<dmt-config-<project-id-or-customer-name-given-in-deployment>/validation/teradata/validation_params.csv",
-         "validation_type":"<row/column>",
-         "validation_mode":"<gke/cloudrun>",
-         "pod_operator_mem" :"4000M",
-         "pod_operator_cpu" :"800m"
-     }
-  }
+         "local-processing-space": "/opt/migration_project_teradata_bq/local_processing_space",
+         "max-local-storage": "200GB",
+         "gcs-upload-chunk-size": "32MB",
+         "use-tpt": true,
+         "retain-tpt-files": false,
+         "max-sessions": 0,
+         "spool-mode": "NoSpool",
+         "max-parallel-upload": 2,
+         "max-parallel-extract-threads": 2,
+         "session-charset": "UTF8",
+         "max-unload-file-size": "2GB"
+      }
+   },
+   "validation_config": {
+      "source_config": {
+         "source_type": "Teradata",
+         "host": "<source_db_host_or_ip>",
+         "port": 1025,
+         "user-name": "<source_db_username>",
+         "password": "secret-<teradata_secret_name>"
+      },
+      "target_config": {
+         "target_type": "BigQuery",
+         "project-id": "<project-id>"
+      },
+      "validation_params_file_path": "gs://<dmt-config-<project-id-or-customer-name-given-in-deployment>/validation/teradata/validation_params.csv",
+      "validation_type": "<row/column>",
+      "validation_mode": "<gke/cloudrun>",
+      "pod_operator_mem": "4000M",
+      "pod_operator_cpu": "800m"
+   }
+}

--- a/samples/configs/teradata/sampleconfig_for_ddl_sql_teradata.json
+++ b/samples/configs/teradata/sampleconfig_for_ddl_sql_teradata.json
@@ -80,16 +80,16 @@
             "host": "<source_db_host_ip>",
             "port": 1025,
             "user-name": "<source_db_username>",
-            "password": "secret:<secret_name>"
+            "password": "secret-<secret_name>"
         },
         "target_config": {
             "target_type": "BigQuery",
             "project-id": "<project_id>"
         },
-        "validation_params_file_path" : "gs://<dmt-config-<project-id-or-customer-name-given-in-deployment>/validation/teradata/validation_params.csv",
-        "validation_mode":"<gke/cloudrun>",
+        "validation_params_file_path": "gs://<dmt-config-<project-id-or-customer-name-given-in-deployment>/validation/teradata/validation_params.csv",
+        "validation_mode": "<gke/cloudrun>",
         "validation_type": "column",
-        "pod_operator_mem" :"4000M",
-        "pod_operator_cpu" :"800m"
+        "pod_operator_mem": "4000M",
+        "pod_operator_cpu": "800m"
     }
 }

--- a/src/common_utils/constants.py
+++ b/src/common_utils/constants.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SECRET_PREFIX = "secret-"

--- a/src/common_utils/constants.py
+++ b/src/common_utils/constants.py
@@ -12,4 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# SECRET_PREFIX hardcoded in 'src/translation/dvt/main.py' and 'src/datamigration/scripts/teradata/agent_controller/controller.py'
 SECRET_PREFIX = "secret-"

--- a/src/common_utils/operators/reporting_operator.py
+++ b/src/common_utils/operators/reporting_operator.py
@@ -114,7 +114,7 @@ class ReportingOperator(BaseOperator):
                     )
 
                     # Task instance with map index not a -1 means task is Dynamically mapped task
-                    if task_instance.map_index is not -1:
+                    if task_instance.map_index != -1:
                         logging.info(
                             f"Failed task {task_instance.task_id} is part of Dynamic Task Mapping"
                         )

--- a/src/common_utils/tests/mock/sample_config_for_sql.json
+++ b/src/common_utils/tests/mock/sample_config_for_sql.json
@@ -10,16 +10,16 @@
       "host": "<source_db_host_ip>",
       "port": 1025,
       "user-name": "<source_db_username>",
-      "password": "secret:<secret_name>"
+      "password": "secret-<secret_name>"
     },
     "target_config": {
       "target_type": "BigQuery",
       "project-id": "<project_id>"
     },
-    "validation_params_file_path" : "gs://<dmt-config-<project-id-or-customer-name-given-in-deployment>/validation/teradata/validation_params.csv",
-    "validation_mode":"cloudrun",
+    "validation_params_file_path": "gs://<dmt-config-<project-id-or-customer-name-given-in-deployment>/validation/teradata/validation_params.csv",
+    "validation_mode": "cloudrun",
     "validation_type": "column",
-    "pod_operator_mem" :"4000M",
-    "pod_operator_cpu" :"800m"
+    "pod_operator_mem": "4000M",
+    "pod_operator_cpu": "800m"
   }
 }

--- a/src/common_utils/tests/mock/sampleconfig_for_ddl_sql_teradata.json
+++ b/src/common_utils/tests/mock/sampleconfig_for_ddl_sql_teradata.json
@@ -80,16 +80,16 @@
       "host": "<source_db_host_ip>",
       "port": 1025,
       "user-name": "<source_db_username>",
-      "password": "secret:<secret_name>"
+      "password": "secret-<secret_name>"
     },
     "target_config": {
       "target_type": "BigQuery",
       "project-id": "<project_id>"
     },
-    "validation_params_file_path" : "gs://<dmt-config-<project-id-or-customer-name-given-in-deployment>/validation/teradata/validation_params.csv",
-    "validation_mode":"<gke/cloudrun>",
+    "validation_params_file_path": "gs://<dmt-config-<project-id-or-customer-name-given-in-deployment>/validation/teradata/validation_params.csv",
+    "validation_mode": "<gke/cloudrun>",
     "validation_type": "column",
-    "pod_operator_mem" :"4000M",
-    "pod_operator_cpu" :"800m"
+    "pod_operator_mem": "4000M",
+    "pod_operator_cpu": "800m"
   }
 }

--- a/src/datamigration/dags/redshift/redshift_data_load_dag.py
+++ b/src/datamigration/dags/redshift/redshift_data_load_dag.py
@@ -162,12 +162,12 @@ def _create_bq_transfer_config_json(batch_idx, ti) -> None:
     database_password = redshift_params["database_password"]
     if database_password.startswith(constants.SECRET_PREFIX):
         database_password = Variable.get(
-            database_password.lstrip(constants.SECRET_PREFIX)
+            database_password.removeprefix(constants.SECRET_PREFIX)
         )
     secret_access_key = redshift_params["secret_access_key"]
     if secret_access_key.startswith(constants.SECRET_PREFIX):
         secret_access_key = Variable.get(
-            secret_access_key.lstrip(constants.SECRET_PREFIX)
+            secret_access_key.removeprefix(constants.SECRET_PREFIX)
         )
     table_name = ti.xcom_pull(
         key="batch_table_names_list", task_ids=GENERATE_BATCHES_DAG_TASK

--- a/src/datamigration/dags/redshift/redshift_data_load_dag.py
+++ b/src/datamigration/dags/redshift/redshift_data_load_dag.py
@@ -15,6 +15,7 @@ from googleapiclient import _auth as auth
 from googleapiclient.errors import HttpError
 
 from common_utils import (
+    constants,
     custom_user_agent,
     discovery_util,
     parallelization_utils,
@@ -51,8 +52,6 @@ REDSHIFT_TRANSFER_TRACKING_TABLE_NAME = "dmt_redshift_transfer_tracking"
 
 # DTS DAG constants
 DTS_TABLE_NAME_SEPARATOR = ";"
-
-SECRET_PREFIX = "secret:"
 
 DAG_ID = "redshift_data_load_dag"
 
@@ -161,11 +160,15 @@ def _create_bq_transfer_config_json(batch_idx, ti) -> None:
 
     redshift_params = user_config["transfer_config"]["params"]
     database_password = redshift_params["database_password"]
-    if database_password.startswith(SECRET_PREFIX):
-        database_password = Variable.get(database_password.split(SECRET_PREFIX)[1])
+    if database_password.startswith(constants.SECRET_PREFIX):
+        database_password = Variable.get(
+            database_password.lstrip(constants.SECRET_PREFIX)
+        )
     secret_access_key = redshift_params["secret_access_key"]
-    if secret_access_key.startswith(SECRET_PREFIX):
-        secret_access_key = Variable.get(secret_access_key.split(SECRET_PREFIX)[1])
+    if secret_access_key.startswith(constants.SECRET_PREFIX):
+        secret_access_key = Variable.get(
+            secret_access_key.lstrip(constants.SECRET_PREFIX)
+        )
     table_name = ti.xcom_pull(
         key="batch_table_names_list", task_ids=GENERATE_BATCHES_DAG_TASK
     )[batch_idx]

--- a/src/datamigration/scripts/teradata/agent_controller/controller.py
+++ b/src/datamigration/scripts/teradata/agent_controller/controller.py
@@ -14,6 +14,8 @@ _AGENT_KILL_SCRIPT = os.path.join(_ROOT_DIR, "scripts", "kill_agent.sh")
 
 _LOGGER = logging.getLogger(__name__)
 
+SECRET_PREFIX = "secret-"
+
 
 class Controller:
     def __init__(self, data):
@@ -72,8 +74,8 @@ class Controller:
             ]
         else:
             password = agent_config["teradata-config"]["connection"]["password"]
-            if password.startswith("secret:"):
-                secret_key = password.split("secret:")[1]
+            if password.startswith(SECRET_PREFIX):
+                secret_key = password.lstrip(SECRET_PREFIX)
                 secret_resource_id = f"projects/{_PROJECT_ID}/secrets/secret-{secret_key}/versions/latest"
             else:
                 secret_resource_id = None

--- a/src/datamigration/scripts/teradata/agent_controller/controller.py
+++ b/src/datamigration/scripts/teradata/agent_controller/controller.py
@@ -75,8 +75,9 @@ class Controller:
         else:
             password = agent_config["teradata-config"]["connection"]["password"]
             if password.startswith(SECRET_PREFIX):
-                secret_key = password.lstrip(SECRET_PREFIX)
-                secret_resource_id = f"projects/{_PROJECT_ID}/secrets/secret-{secret_key}/versions/latest"
+                secret_resource_id = (
+                    f"projects/{_PROJECT_ID}/secrets/{password}/versions/latest"
+                )
             else:
                 secret_resource_id = None
 

--- a/src/tests/end_to_end/config/data/teradata/teradata_data.json
+++ b/src/tests/end_to_end/config/data/teradata/teradata_data.json
@@ -1,49 +1,49 @@
 {
-  "unique_id":"{{ unique_id }}",
-  "batchDistribution":1,
-  "type":"data",
-  "source":"teradata",
+  "unique_id": "{{ unique_id }}",
+  "batchDistribution": 1,
+  "type": "data",
+  "source": "teradata",
   "table_list_file": "gs://{{ data_bucket_name }}/files/teradata/{{ data_mig_table_list_file }}",
-  "transfer_config":{
-    "dataSourceId":"on_premises",
-    "displayName":"{{ unique_id }}",
-    "params":{
-      "database_type":"Teradata",
-      "bucket":"{{ bucket_name }}",
-      "database_name":"{{ source_schema }}",
-      "agent_service_account":"dmt-teradata-agent-vm@{{ project_id }}.iam.gserviceaccount.com"
+  "transfer_config": {
+    "dataSourceId": "on_premises",
+    "displayName": "{{ unique_id }}",
+    "params": {
+      "database_type": "Teradata",
+      "bucket": "{{ bucket_name }}",
+      "database_name": "{{ source_schema }}",
+      "agent_service_account": "dmt-teradata-agent-vm@{{ project_id }}.iam.gserviceaccount.com"
     },
-    "emailPreferences":{
-      "enableFailureEmail":false
+    "emailPreferences": {
+      "enableFailureEmail": false
     },
     "notificationPubsubTopic": "projects/{{ project_id }}/topics/dmt-teradata-dts-notification-topic-{{ project_id }}",
-    "destinationDatasetId":"{{ target_schema }}"
+    "destinationDatasetId": "{{ target_schema }}"
   },
-  "agent_config":{
-    "transfer-configuration":{
-      "project-id":"{{ project_id }}",
-      "location":"us"
+  "agent_config": {
+    "transfer-configuration": {
+      "project-id": "{{ project_id }}",
+      "location": "us"
     },
-    "source-type":"teradata",
-    "console-log":false,
-    "silent":false,
-    "teradata-config":{
-      "connection":{
-        "host":"{{ source_ip }}",
+    "source-type": "teradata",
+    "console-log": false,
+    "silent": false,
+    "teradata-config": {
+      "connection": {
+        "host": "{{ source_ip }}",
         "username": "{{ source_username }}",
         "secret_resource_id": "projects/{{ project_id }}/secrets/secret-{{ secret_name }}/versions/latest"
       },
-      "local-processing-space":"/opt/migration_project_teradata_bq/local_processing_space",
-      "max-local-storage":"200GB",
-      "gcs-upload-chunk-size":"32MB",
-      "use-tpt":true,
-      "retain-tpt-files":false,
-      "max-sessions":0,
-      "spool-mode":"NoSpool",
-      "max-parallel-upload":2,
-      "max-parallel-extract-threads":2,
-      "session-charset":"UTF8",
-      "max-unload-file-size":"2GB"
+      "local-processing-space": "/opt/migration_project_teradata_bq/local_processing_space",
+      "max-local-storage": "200GB",
+      "gcs-upload-chunk-size": "32MB",
+      "use-tpt": true,
+      "retain-tpt-files": false,
+      "max-sessions": 0,
+      "spool-mode": "NoSpool",
+      "max-parallel-upload": 2,
+      "max-parallel-extract-threads": 2,
+      "session-charset": "UTF8",
+      "max-unload-file-size": "2GB"
     }
   },
   "validation_config": {
@@ -52,16 +52,16 @@
       "host": "{{ source_ip }}",
       "port": 1025,
       "user-name": "{{ source_username }}",
-      "password": "secret:{{ secret_name }}"
+      "password": "secret-{{ secret_name }}"
     },
     "target_config": {
       "target_type": "BigQuery",
       "project-id": "{{ project_id }}"
     },
-    "validation_params_file_path" : "gs://{{ config_bucket_name }}/validation/teradata/{{ validation_mapping_file }}",
-    "validation_mode":"{{ validation_mode }}",
-    "validation_type":"column",
-    "pod_operator_mem" :"4000M",
-    "pod_operator_cpu" :"800m"
+    "validation_params_file_path": "gs://{{ config_bucket_name }}/validation/teradata/{{ validation_mapping_file }}",
+    "validation_mode": "{{ validation_mode }}",
+    "validation_type": "column",
+    "pod_operator_mem": "4000M",
+    "pod_operator_cpu": "800m"
   }
 }

--- a/src/tests/end_to_end/config/ddl/oracle/oracle_ddl.json
+++ b/src/tests/end_to_end/config/ddl/oracle/oracle_ddl.json
@@ -1,5 +1,5 @@
 {
-    "batchDistribution": 1,  
+    "batchDistribution": 1,
     "unique_id": "{{ unique_id }}",
     "type": "ddl",
     "source": "oracle",
@@ -79,16 +79,16 @@
             "port": 1521,
             "user": "{{ source_username }}",
             "database": "{{ source_dbname }}",
-            "password": "secret:{{ secret_name }}"
+            "password": "secret-{{ secret_name }}"
         },
         "target_config": {
             "target_type": "BigQuery",
             "project-id": "{{ project_id }}"
         },
-        "validation_params_file_path" : "gs://{{ config_bucket_name }}/validation/oracle/{{ validation_mapping_file }}",
-        "validation_mode":"{{ validation_mode }}",
+        "validation_params_file_path": "gs://{{ config_bucket_name }}/validation/oracle/{{ validation_mapping_file }}",
+        "validation_mode": "{{ validation_mode }}",
         "validation_type": "schema",
-        "pod_operator_mem" :"4000M", 
-        "pod_operator_cpu" :"800m"
+        "pod_operator_mem": "4000M",
+        "pod_operator_cpu": "800m"
     }
 }

--- a/src/tests/end_to_end/config/ddl/teradata/teradata_ddl.json
+++ b/src/tests/end_to_end/config/ddl/teradata/teradata_ddl.json
@@ -1,5 +1,5 @@
 {
-    "batchDistribution": 1,  
+    "batchDistribution": 1,
     "unique_id": "{{ unique_id }}",
     "type": "ddl",
     "source": "teradata",
@@ -80,16 +80,16 @@
             "host": "{{ source_ip }}",
             "port": 1025,
             "user-name": "{{ source_username }}",
-            "password": "secret:{{ secret_name }}"
+            "password": "secret-{{ secret_name }}"
         },
         "target_config": {
             "target_type": "BigQuery",
             "project-id": "{{ project_id }}"
         },
-        "validation_params_file_path" : "gs://{{ config_bucket_name }}/validation/teradata/{{ validation_mapping_file }}",
-        "validation_mode":"{{ validation_mode }}",
+        "validation_params_file_path": "gs://{{ config_bucket_name }}/validation/teradata/{{ validation_mapping_file }}",
+        "validation_mode": "{{ validation_mode }}",
         "validation_type": "schema",
-        "pod_operator_mem" :"4000M",
-        "pod_operator_cpu" :"800m"
+        "pod_operator_mem": "4000M",
+        "pod_operator_cpu": "800m"
     }
 }

--- a/src/tests/end_to_end/config/sql/teradata/teradata_sql.json
+++ b/src/tests/end_to_end/config/sql/teradata/teradata_sql.json
@@ -1,5 +1,5 @@
 {
-    "batchDistribution": 1,  
+    "batchDistribution": 1,
     "unique_id": "{{ unique_id }}",
     "type": "sql",
     "source": "teradata",
@@ -80,16 +80,16 @@
             "host": "{{ source_ip }}",
             "port": 1025,
             "user-name": "{{ source_username }}",
-            "password": "secret:{{ secret_name }}"
+            "password": "secret-{{ secret_name }}"
         },
         "target_config": {
             "target_type": "BigQuery",
             "project-id": "{{ project_id }}"
         },
-        "validation_params_file_path" : "gs://{{ config_bucket_name }}/validation/teradata/{{ validation_mapping_file }}",
+        "validation_params_file_path": "gs://{{ config_bucket_name }}/validation/teradata/{{ validation_mapping_file }}",
         "validation_mode": "{{ validation_mode }}",
         "validation_type": "{{ validation_type }}",
-        "pod_operator_mem" :"4000M",
-        "pod_operator_cpu" :"800m"
+        "pod_operator_mem": "4000M",
+        "pod_operator_cpu": "800m"
     }
 }

--- a/src/tests/unit/input_validation_utils_test.py
+++ b/src/tests/unit/input_validation_utils_test.py
@@ -107,11 +107,11 @@ def test_check_secret_exists(
         )
 
     assert (
-        input_validation_utils.check_secret_exists(project_id, secret_name)
+        input_validation_utils.check_secret_access(project_id, secret_name)
         == expected_result
     )
     mock_secretmanager.SecretManagerServiceClient.return_value.get_secret.assert_called_once_with(
-        request={"name": f"projects/{project_id}/secrets/{secret_name}"}
+        request={"name": f"projects/{project_id}/secrets/{secret_name}/versions/latest"}
     )
 
 

--- a/src/tests/unit/input_validation_utils_test.py
+++ b/src/tests/unit/input_validation_utils_test.py
@@ -1,0 +1,168 @@
+# from translation.dags.translation_utils import input_validation_utils
+
+
+# def test_check_gcs_bucket_exists():
+#     BUCKET_EXISTS = "gs://dmt-config-pso-data-migration-tool-test"
+#     BUCKET_DNE = "gs://dmt-config-pso-data-migration-tool-test-does-not-exist-123"
+#     expect_exists = input_validation_utils.check_gcs_bucket_exists(BUCKET_EXISTS)
+#     assert expect_exists is True
+
+#     expect_dne = input_validation_utils.check_gcs_bucket_exists(BUCKET_DNE)
+#     assert expect_dne is False
+
+# def test_check_gcs_file_exists():
+#     # Asserts whether a gcs file exists from two gcs paths
+
+
+# def test_check_gcs_directory_not_empty():
+
+
+# def test_check_secret_exists():
+
+# def test_split_gcs_path():
+
+# def normalize_and_validate_config():
+#     CONFIG_IN = {
+#         "source": "TeRADAtA"
+#         ""
+#     }
+#     CONFIG_OUT = {
+
+#     }
+
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+from airflow.exceptions import AirflowFailException
+from google.api_core.exceptions import NotFound
+
+from common_utils import constants
+from translation.dags.translation_utils import input_validation_utils
+
+# python -m pytest tests/unit/input_validation_utils_test.py
+
+
+@pytest.mark.parametrize(
+    "gs_path, expected_result",
+    [
+        ("gs://mybucket", True),
+        ("gs://mybucket/prefix", True),
+        ("gs://mybucket/prefix/file.txt", True),
+        ("gs://nonexistentbucket", False),
+    ],
+)
+@mock.patch("translation.dags.translation_utils.input_validation_utils.storage")
+def test_check_gcs_bucket_exists(mock_storage, gs_path, expected_result):
+    mock_bucket = mock.MagicMock()
+    mock_bucket.exists.return_value = expected_result
+    mock_storage.Client.return_value.bucket.return_value = mock_bucket
+
+    assert input_validation_utils.check_gcs_bucket_exists(gs_path) == expected_result
+    mock_storage.Client.return_value.bucket.assert_called_once_with(
+        gs_path.split("/")[2]
+    )
+
+
+@pytest.mark.parametrize(
+    "gs_path, expected_result",
+    [
+        ("gs://mybucket/dir1/file1.csv", True),
+        ("gs://mybucket/file1.csv", True),
+        ("gs://mybucket/nonexistentfile.csv", False),
+        ("gs://nonexistentbucket/dir1/file1.csv", False),
+    ],
+)
+@mock.patch("translation.dags.translation_utils.input_validation_utils.storage")
+def test_check_gcs_file_exists(mock_storage, gs_path, expected_result):
+    mock_blob = mock.MagicMock()
+    mock_blob.exists.return_value = expected_result
+    mock_storage.Client.return_value.bucket.return_value.blob.return_value = mock_blob
+
+    assert input_validation_utils.check_gcs_file_exists(gs_path) == expected_result
+    mock_storage.Client.return_value.bucket.assert_called_once()
+    mock_storage.Client.return_value.bucket.return_value.blob.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "gs_path, expected_result",
+    [
+        ("gs://mybucket/dir1/", True),
+        ("gs://mybucket/dir2/", False),
+        ("gs://nonexistentbucket/dir1/", False),
+    ],
+)
+@mock.patch("translation.dags.translation_utils.input_validation_utils.storage")
+def test_check_gcs_directory_not_empty(mock_storage, gs_path, expected_result):
+    mock_bucket = mock.MagicMock()
+    mock_bucket.exists.return_value = True
+    mock_blob = mock.MagicMock()
+    mock_bucket.list_blobs.return_value = [mock_blob] if expected_result else []
+    mock_storage.Client.return_value.bucket.return_value = mock_bucket
+
+    assert (
+        input_validation_utils.check_gcs_directory_not_empty(gs_path) == expected_result
+    )
+    mock_storage.Client.return_value.bucket.assert_called_once()
+    mock_bucket.list_blobs.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "project_id, secret_name, expected_result",
+    [
+        ("myproject", "mysecret", True),
+        ("myproject", "nonexistentsecret", False),
+    ],
+)
+@mock.patch("translation.dags.translation_utils.input_validation_utils.secretmanager")
+def test_check_secret_exists(
+    mock_secretmanager, project_id, secret_name, expected_result
+):
+    if expected_result is True:
+        mock_secretmanager.SecretManagerServiceClient.return_value.get_secret.return_value = (
+            mock.MagicMock()
+        )
+    else:
+        mock_secretmanager.SecretManagerServiceClient.return_value.get_secret.side_effect = NotFound(
+            "testing"
+        )
+
+    assert (
+        input_validation_utils.check_secret_exists(project_id, secret_name)
+        == expected_result
+    )
+    mock_secretmanager.SecretManagerServiceClient.return_value.get_secret.assert_called_once_with(
+        request={"name": f"projects/{project_id}/secrets/{secret_name}"}
+    )
+
+
+@pytest.mark.parametrize(
+    "gcs_path, expected_bucket_name, expected_directory_path",
+    [
+        (
+            "gs://mybucket/dir1/dir2/file1.csv",
+            "mybucket",
+            "dir1/dir2/file1.csv",
+        ),
+        ("gs://mybucket/file1.csv", "mybucket", "file1.csv"),
+        ("gs://mybucket/", "mybucket", ""),
+    ],
+)
+def test_split_gcs_path(gcs_path, expected_bucket_name, expected_directory_path):
+    bucket_name, directory_path = input_validation_utils.split_gcs_path(gcs_path)
+    assert bucket_name == expected_bucket_name
+    assert directory_path == expected_directory_path

--- a/src/tests/unit/input_validation_utils_test.py
+++ b/src/tests/unit/input_validation_utils_test.py
@@ -1,36 +1,3 @@
-# from translation.dags.translation_utils import input_validation_utils
-
-
-# def test_check_gcs_bucket_exists():
-#     BUCKET_EXISTS = "gs://dmt-config-pso-data-migration-tool-test"
-#     BUCKET_DNE = "gs://dmt-config-pso-data-migration-tool-test-does-not-exist-123"
-#     expect_exists = input_validation_utils.check_gcs_bucket_exists(BUCKET_EXISTS)
-#     assert expect_exists is True
-
-#     expect_dne = input_validation_utils.check_gcs_bucket_exists(BUCKET_DNE)
-#     assert expect_dne is False
-
-# def test_check_gcs_file_exists():
-#     # Asserts whether a gcs file exists from two gcs paths
-
-
-# def test_check_gcs_directory_not_empty():
-
-
-# def test_check_secret_exists():
-
-# def test_split_gcs_path():
-
-# def normalize_and_validate_config():
-#     CONFIG_IN = {
-#         "source": "TeRADAtA"
-#         ""
-#     }
-#     CONFIG_OUT = {
-
-#     }
-
-
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,10 +15,8 @@
 from unittest import mock
 
 import pytest
-from airflow.exceptions import AirflowFailException
 from google.api_core.exceptions import NotFound
 
-from common_utils import constants
 from translation.dags.translation_utils import input_validation_utils
 
 # python -m pytest tests/unit/input_validation_utils_test.py

--- a/src/tests/unit/input_validation_utils_test.py
+++ b/src/tests/unit/input_validation_utils_test.py
@@ -98,11 +98,11 @@ def test_check_secret_access(
     mock_secretmanager, project_id, secret_name, expected_result
 ):
     if expected_result is True:
-        mock_secretmanager.SecretManagerServiceClient.return_value.get_secret.return_value = (
+        mock_secretmanager.SecretManagerServiceClient.return_value.access_secret_version.return_value = (
             mock.MagicMock()
         )
     else:
-        mock_secretmanager.SecretManagerServiceClient.return_value.get_secret.side_effect = NotFound(
+        mock_secretmanager.SecretManagerServiceClient.return_value.access_secret_version.side_effect = NotFound(
             "testing"
         )
 
@@ -110,7 +110,7 @@ def test_check_secret_access(
         input_validation_utils.check_secret_access(project_id, secret_name)
         == expected_result
     )
-    mock_secretmanager.SecretManagerServiceClient.return_value.get_secret.assert_called_once_with(
+    mock_secretmanager.SecretManagerServiceClient.return_value.access_secret_version.assert_called_once_with(
         request={"name": f"projects/{project_id}/secrets/{secret_name}/versions/latest"}
     )
 

--- a/src/tests/unit/input_validation_utils_test.py
+++ b/src/tests/unit/input_validation_utils_test.py
@@ -94,7 +94,7 @@ def test_check_gcs_directory_not_empty(mock_storage, gs_path, expected_result):
     ],
 )
 @mock.patch("translation.dags.translation_utils.input_validation_utils.secretmanager")
-def test_check_secret_exists(
+def test_check_secret_access(
     mock_secretmanager, project_id, secret_name, expected_result
 ):
     if expected_result is True:

--- a/src/translation/dags/controller_dag.py
+++ b/src/translation/dags/controller_dag.py
@@ -14,6 +14,9 @@ from google.cloud import bigquery, storage
 
 from common_utils import custom_user_agent
 from common_utils.operators.reporting_operator import ReportingOperator
+from translation.dags.translation_utils.input_validation_utils import (
+    normalize_and_validate_config,
+)
 
 CUSTOM_RUN_ID_KEY = "unique_id"
 DAG_ID = "controller_dag"
@@ -72,7 +75,8 @@ def _load_config(ti, **kwargs) -> None:
     )
     event_json = kwargs["dag_run"].conf
     event_type = event_json["message"]["attributes"]["eventType"]
-    if event_type == "OBJECT_FINALIZE":
+
+    if event_type == "OBJECT_FINALIZE":  # New config file dropped
         message = event_json["message"]
         print(f"message : {message}")
         bucket_id = message["attributes"]["bucketId"]
@@ -82,12 +86,16 @@ def _load_config(ti, **kwargs) -> None:
         bucket = client.get_bucket(bucket_id)
         blob = storage.Blob(object_id, bucket)
         raw_config = blob.download_as_bytes()
+
         config = json.loads(raw_config)
+        config = normalize_and_validate_config(PROJECT_ID, config)
         if CUSTOM_RUN_ID_KEY not in config:
             config[CUSTOM_RUN_ID_KEY] = datetime.datetime.now().strftime("%x %H:%M:%S")
+
         ti.xcom_push(key="config", value=config)
         ti.xcom_push(key="bucket_id", value=bucket_id)
         ti.xcom_push(key="object_id", value=object_id)
+
     elif event_type == "TRANSFER_RUN_FINISHED":
         config = json.loads(base64.b64decode(event_json["message"]["data"]))
         ti.xcom_push(key="config", value=config)
@@ -96,6 +104,7 @@ def _load_config(ti, **kwargs) -> None:
 
 def _prepare_data_for_next_dag(ti, **kwargs):
     event_type = ti.xcom_pull(key="event_type", task_ids="load_config")
+    next_dag_config = None
     if event_type == "OBJECT_FINALIZE":
         config = ti.xcom_pull(key="config", task_ids="load_config")
         bucket_id = ti.xcom_pull(key="bucket_id", task_ids="load_config")
@@ -107,7 +116,7 @@ def _prepare_data_for_next_dag(ti, **kwargs):
                 next_dag_config = {"config": config}
             else:
                 print(f"Unsupported data source : {data_source}")
-                next_dag_config = None
+
         elif op_type == "data":
             next_dag_config = {
                 "config": config,
@@ -116,7 +125,7 @@ def _prepare_data_for_next_dag(ti, **kwargs):
             }
         else:
             print(f"Error: Unsupported operation type: {op_type}")
-            next_dag_config = None
+
     elif event_type == "TRANSFER_RUN_FINISHED":
         config = ti.xcom_pull(key="config", task_ids="load_config")
         data_source = config["dataSourceId"]
@@ -136,13 +145,13 @@ def _prepare_data_for_next_dag(ti, **kwargs):
             }
     else:
         print(f"Unsupported event type: {event_type}")
-        next_dag_config = None
 
     ti.xcom_push(key="next_dag_config", value=next_dag_config)
 
 
 def _determine_next_dag(ti, **kwargs):
     event_type = ti.xcom_pull(key="event_type", task_ids="load_config")
+    next_dag_id = None
     if event_type == "OBJECT_FINALIZE":
         config = ti.xcom_pull(key="config", task_ids="load_config")
         op_type = config["type"]
@@ -165,7 +174,7 @@ def _determine_next_dag(ti, **kwargs):
                 next_dag_id = EXTRACT_DDL_DAG_ID
             else:
                 print(f"Error: Unsupported data source: {data_source}")
-                next_dag_id = None
+
         elif op_type == "data":
             if data_source == "teradata":
                 next_dag_id = DATA_LOAD_TERADATA_DAG_ID
@@ -177,7 +186,7 @@ def _determine_next_dag(ti, **kwargs):
                 next_dag_id = DATA_LOAD_REDSHIFT_DAG_ID
         else:
             print(f"Unsupported operation type: {op_type}")
-            next_dag_id = None
+
     elif event_type == "TRANSFER_RUN_FINISHED":
         config = ti.xcom_pull(key="config", task_ids="load_config")
         data_source = config["dataSourceId"]
@@ -187,7 +196,6 @@ def _determine_next_dag(ti, **kwargs):
             next_dag_id = REDSHIFT_TRANSFER_RUN_LOG_DAG_ID
     else:
         print(f"Unsupported event type: {event_type}")
-        next_dag_id = None
 
     if next_dag_id is None:
         next_task = "end_task"

--- a/src/translation/dags/controller_dag.py
+++ b/src/translation/dags/controller_dag.py
@@ -11,12 +11,10 @@ from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.utils.trigger_rule import TriggerRule
 from google.api_core.client_info import ClientInfo
 from google.cloud import bigquery, storage
+from translation_utils.input_validation_utils import normalize_and_validate_config
 
 from common_utils import custom_user_agent
 from common_utils.operators.reporting_operator import ReportingOperator
-from translation.dags.translation_utils.input_validation_utils import (
-    normalize_and_validate_config,
-)
 
 CUSTOM_RUN_ID_KEY = "unique_id"
 DAG_ID = "controller_dag"

--- a/src/translation/dags/translation_utils/ddl_extraction_utils/build_oracle_ddl_extraction_group.py
+++ b/src/translation/dags/translation_utils/ddl_extraction_utils/build_oracle_ddl_extraction_group.py
@@ -13,11 +13,10 @@ from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.utils.task_group import TaskGroup
 from google.cloud import bigquery, storage
 
-from common_utils import storage_utils
+from common_utils import constants, storage_utils
 
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
 
-SECRET_PREFIX = "secret:"
 
 # Storage utils object
 gcs_util = storage_utils.StorageUtils()
@@ -55,8 +54,8 @@ def _extract_ddl(ti, **kwargs):
         host = config["validation_config"]["source_config"]["host"]
         port = config["validation_config"]["source_config"]["port"]
         serviceName = config["validation_config"]["source_config"]["database"]
-        if password.startswith(SECRET_PREFIX):
-            password = Variable.get(password[len(SECRET_PREFIX) :])
+        if password.startswith(constants.SECRET_PREFIX):
+            password = Variable.get(password.lstrip(constants.SECRET_PREFIX))
         con = oracledb.connect(
             user=user, password=password, host=host, port=port, service_name=serviceName
         )

--- a/src/translation/dags/translation_utils/ddl_extraction_utils/build_oracle_ddl_extraction_group.py
+++ b/src/translation/dags/translation_utils/ddl_extraction_utils/build_oracle_ddl_extraction_group.py
@@ -55,7 +55,7 @@ def _extract_ddl(ti, **kwargs):
         port = config["validation_config"]["source_config"]["port"]
         serviceName = config["validation_config"]["source_config"]["database"]
         if password.startswith(constants.SECRET_PREFIX):
-            password = Variable.get(password.lstrip(constants.SECRET_PREFIX))
+            password = Variable.get(password.removeprefix(constants.SECRET_PREFIX))
         con = oracledb.connect(
             user=user, password=password, host=host, port=port, service_name=serviceName
         )

--- a/src/translation/dags/translation_utils/ddl_extraction_utils/build_redshift_ddl_extraction_group.py
+++ b/src/translation/dags/translation_utils/ddl_extraction_utils/build_redshift_ddl_extraction_group.py
@@ -12,11 +12,10 @@ from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.utils.task_group import TaskGroup
 from google.cloud import bigquery
 
-from common_utils import storage_utils
+from common_utils import constants, storage_utils
 
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
 
-SECRET_PREFIX = "secret:"
 
 # Storage utils object
 gcs_util = storage_utils.StorageUtils()
@@ -37,8 +36,8 @@ def _extract_redshift_ddl(ti, **kwargs):
     portno = source_config["port"]
     username = source_config["user"].lower()
     password = source_config["password"]
-    if password.startswith(SECRET_PREFIX):
-        password = Variable.get(password[len(SECRET_PREFIX) :])
+    if password.startswith(constants.SECRET_PREFIX):
+        password = Variable.get(password.lstrip(constants.SECRET_PREFIX))
 
     source_schema = config["migrationTask"]["translationConfigDetails"][
         "nameMappingList"

--- a/src/translation/dags/translation_utils/ddl_extraction_utils/build_redshift_ddl_extraction_group.py
+++ b/src/translation/dags/translation_utils/ddl_extraction_utils/build_redshift_ddl_extraction_group.py
@@ -37,7 +37,7 @@ def _extract_redshift_ddl(ti, **kwargs):
     username = source_config["user"].lower()
     password = source_config["password"]
     if password.startswith(constants.SECRET_PREFIX):
-        password = Variable.get(password.lstrip(constants.SECRET_PREFIX))
+        password = Variable.get(password.removeprefix(constants.SECRET_PREFIX))
 
     source_schema = config["migrationTask"]["translationConfigDetails"][
         "nameMappingList"

--- a/src/translation/dags/translation_utils/ddl_extraction_utils/build_teradata_ddl_extraction_group.py
+++ b/src/translation/dags/translation_utils/ddl_extraction_utils/build_teradata_ddl_extraction_group.py
@@ -18,11 +18,9 @@ from airflow.utils.task_group import TaskGroup
 from google.cloud import bigquery
 from translation_utils import csv_utils
 
-from common_utils import storage_utils
+from common_utils import constants, storage_utils
 
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
-
-SECRET_PREFIX = "secret:"
 
 # Script bucket name and folder name to copy in data directory
 CONFIG_BUCKET_NAME = os.environ.get("CONFIG_BUCKET_NAME")
@@ -98,8 +96,8 @@ def _prepare_arguments(ti, **kwargs) -> None:
     connection_args += ",user:" + source_config["user-name"]
 
     password = source_config["password"]
-    if password.startswith(SECRET_PREFIX):
-        password = Variable.get(password[len(SECRET_PREFIX) :])
+    if password.startswith(constants.SECRET_PREFIX):
+        password = Variable.get(password.lstrip(constants.SECRET_PREFIX))
     connection_args += ",password:" + password
 
     source_schema = config["migrationTask"]["translationConfigDetails"][

--- a/src/translation/dags/translation_utils/ddl_extraction_utils/build_teradata_ddl_extraction_group.py
+++ b/src/translation/dags/translation_utils/ddl_extraction_utils/build_teradata_ddl_extraction_group.py
@@ -97,7 +97,7 @@ def _prepare_arguments(ti, **kwargs) -> None:
 
     password = source_config["password"]
     if password.startswith(constants.SECRET_PREFIX):
-        password = Variable.get(password.lstrip(constants.SECRET_PREFIX))
+        password = Variable.get(password.removeprefix(constants.SECRET_PREFIX))
     connection_args += ",password:" + password
 
     source_schema = config["migrationTask"]["translationConfigDetails"][

--- a/src/translation/dags/translation_utils/input_validation_utils.py
+++ b/src/translation/dags/translation_utils/input_validation_utils.py
@@ -53,9 +53,9 @@ def check_gcs_directory_not_empty(gs_path: str) -> bool:
 
 def check_secret_exists(project_id: str, secret_name: str) -> bool:
     client = secretmanager.SecretManagerServiceClient()
-    name = f"projects/{project_id}/secrets/{secret_name}"
+    name = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
     try:
-        client.get_secret(request={"name": f"{name}"})
+        client.access_secret_version(request={"name": f"{name}"})
         return True
     except NotFound:
         return False
@@ -118,7 +118,7 @@ def normalize_and_validate_config(project_id: str, config: dict) -> dict:
             "validation_config"
         ]["source_config"]["password"].startswith(constants.SECRET_PREFIX):
             src_pw_secret = config["validation_config"]["source_config"]["password"]
-            if not check_secret_exists(project_id, src_pw_secret):
+            if not check_secret_access(project_id, src_pw_secret):
                 raise AirflowFailException(
                     f"Secret not found in Secret Manager with the name {src_pw_secret}."
                 )
@@ -127,7 +127,7 @@ def normalize_and_validate_config(project_id: str, config: dict) -> dict:
             "validation_config"
         ]["target_config"]["password"].startswith(constants.SECRET_PREFIX):
             tgt_pw_secret = config["validation_config"]["target_config"]["password"]
-            if not check_secret_exists(project_id, tgt_pw_secret):
+            if not check_secret_access(project_id, tgt_pw_secret):
                 raise AirflowFailException(
                     f"Secret not found in Secret Manager with the name {tgt_pw_secret}."
                 )

--- a/src/translation/dags/translation_utils/input_validation_utils.py
+++ b/src/translation/dags/translation_utils/input_validation_utils.py
@@ -51,7 +51,7 @@ def check_gcs_directory_not_empty(gs_path: str) -> bool:
     return False
 
 
-def check_secret_exists(project_id: str, secret_name: str) -> bool:
+def check_secret_access(project_id: str, secret_name: str) -> bool:
     client = secretmanager.SecretManagerServiceClient()
     name = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
     try:

--- a/src/translation/dags/translation_utils/input_validation_utils.py
+++ b/src/translation/dags/translation_utils/input_validation_utils.py
@@ -74,7 +74,6 @@ def split_gcs_path(gcs_path):
 
 
 def normalize_and_validate_config(project_id: str, config: dict) -> dict:
-    # TODO(dmedora): see what else can be validated, check actual existence. Also which fields should be present in which config types
     # Normalize source name
     if "source" in config:
         config["source"] = config["source"].lower()
@@ -114,7 +113,7 @@ def normalize_and_validate_config(project_id: str, config: dict) -> dict:
                 f"Validation config parameters file not found at validation_params_file_path={validation_params_file}."
             )
 
-        # Check that secret exists in Secret Manager.
+        # Check that secrets exist in Secret Manager.
         if "password" in config["validation_config"]["source_config"] and config[
             "validation_config"
         ]["source_config"]["password"].startswith(constants.SECRET_PREFIX):
@@ -130,7 +129,7 @@ def normalize_and_validate_config(project_id: str, config: dict) -> dict:
             tgt_pw_secret = config["validation_config"]["target_config"]["password"]
             if not check_secret_exists(project_id, tgt_pw_secret):
                 raise AirflowFailException(
-                    f"Secret not found in Secret Manager with the name {src_pw_secret}."
+                    f"Secret not found in Secret Manager with the name {tgt_pw_secret}."
                 )
 
     return config

--- a/src/translation/dags/translation_utils/input_validation_utils.py
+++ b/src/translation/dags/translation_utils/input_validation_utils.py
@@ -1,0 +1,136 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.exceptions import AirflowFailException
+from google.api_core.exceptions import NotFound
+from google.cloud import secretmanager_v1 as secretmanager
+from google.cloud import storage
+
+from common_utils import constants
+
+
+def check_gcs_bucket_exists(gs_path: str) -> bool:
+    bucket_name, _ = split_gcs_path(gs_path)
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    if bucket.exists():
+        return True
+    else:
+        return False
+
+
+def check_gcs_file_exists(gs_path: str) -> bool:
+    bucket_name, file_path = split_gcs_path(gs_path)
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(file_path)
+    return blob.exists()
+
+
+def check_gcs_directory_not_empty(gs_path: str) -> bool:
+    bucket_name, directory_path = split_gcs_path(gs_path)
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    if not bucket.exists():
+        return False
+
+    blobs = bucket.list_blobs(prefix=directory_path)
+    for _ in blobs:
+        return True
+    return False
+
+
+def check_secret_exists(project_id: str, secret_name: str) -> bool:
+    client = secretmanager.SecretManagerServiceClient()
+    name = f"projects/{project_id}/secrets/{secret_name}"
+    try:
+        client.get_secret(request={"name": f"{name}"})
+        return True
+    except NotFound:
+        return False
+    except Exception as e:
+        raise e
+
+
+def split_gcs_path(gcs_path):
+    # Splits a GCS path into bucket name and directory path.
+    # Input: "gs://mybucket/dir1/dir2/file1.csv"
+    # Output: "mybucket", "dir1/dir2/file1.csv"
+    path_parts = gcs_path.lstrip("gs://").split("/", 1)
+    bucket_name = path_parts[0]
+    directory_path = path_parts[1] if len(path_parts) > 1 else ""
+    return bucket_name, directory_path
+
+
+def normalize_and_validate_config(project_id: str, config: dict) -> dict:
+    # TODO(dmedora): see what else can be validated, check actual existence. Also which fields should be present in which config types
+    # Normalize source name
+    if "source" in config:
+        config["source"] = config["source"].lower()
+
+    if "migrationTask" in config:
+        # Normalize GCS paths in the config by removing trailing slashes.
+        translationConfigDetails = config["migrationTask"]["translationConfigDetails"]
+        translationConfigDetails["gcsSourcePath"] = translationConfigDetails[
+            "gcsSourcePath"
+        ].rstrip("/")
+        translationConfigDetails["gcsTargetPath"] = translationConfigDetails[
+            "gcsTargetPath"
+        ].rstrip("/")
+
+        # Check that translation input directory is not empty.
+        if not check_gcs_directory_not_empty(translationConfigDetails["gcsSourcePath"]):
+            raise AirflowFailException(
+                f'No translation input files found at gcsSourcePath={translationConfigDetails["gcsSourcePath"]}.'
+            )
+
+        # Check that translation output bucket exists.
+        if not check_gcs_bucket_exists(translationConfigDetails["gcsTargetPath"]):
+            raise AirflowFailException(
+                f'Translation output bucket does not exist at gcsTargetPath={translationConfigDetails["gcsTargetPath"]}.'
+            )
+
+    if "validation_config" in config:
+        # Note: DVT source names are case-sensitive at present, so it's not easy to normalize them without maintaining a copy of their source name mapping here.
+
+        validation_params_file = config["validation_config"][
+            "validation_params_file_path"
+        ]
+
+        # Check that validation params file exists.
+        if not check_gcs_file_exists(validation_params_file):
+            raise AirflowFailException(
+                f"Validation config parameters file not found at validation_params_file_path={validation_params_file}."
+            )
+
+        # Check that secret exists in Secret Manager.
+        if "password" in config["validation_config"]["source_config"] and config[
+            "validation_config"
+        ]["source_config"]["password"].startswith(constants.SECRET_PREFIX):
+            src_pw_secret = config["validation_config"]["source_config"]["password"]
+            if not check_secret_exists(project_id, src_pw_secret):
+                raise AirflowFailException(
+                    f"Secret not found in Secret Manager with the name {src_pw_secret}."
+                )
+
+        if "password" in config["validation_config"]["target_config"] and config[
+            "validation_config"
+        ]["target_config"]["password"].startswith(constants.SECRET_PREFIX):
+            tgt_pw_secret = config["validation_config"]["target_config"]["password"]
+            if not check_secret_exists(project_id, tgt_pw_secret):
+                raise AirflowFailException(
+                    f"Secret not found in Secret Manager with the name {src_pw_secret}."
+                )
+
+    return config

--- a/src/translation/dags/translation_utils/input_validation_utils.py
+++ b/src/translation/dags/translation_utils/input_validation_utils.py
@@ -67,7 +67,7 @@ def split_gcs_path(gcs_path):
     # Splits a GCS path into bucket name and directory path.
     # Input: "gs://mybucket/dir1/dir2/file1.csv"
     # Output: "mybucket", "dir1/dir2/file1.csv"
-    path_parts = gcs_path.lstrip("gs://").split("/", 1)
+    path_parts = gcs_path.removeprefix("gs://").split("/", 1)
     bucket_name = path_parts[0]
     directory_path = path_parts[1] if len(path_parts) > 1 else ""
     return bucket_name, directory_path

--- a/src/translation/dags/validation_dag.py
+++ b/src/translation/dags/validation_dag.py
@@ -42,7 +42,6 @@ class ValidationEntity(enum.Enum):
 
 
 project_id = os.environ.get("GCP_PROJECT_ID")
-secret_prefix = "secret:"
 
 composer_k8s_cluster_region = os.environ.get("REGION")
 composer_name = os.environ.get("COMPOSER_ENV")
@@ -161,8 +160,6 @@ def connection_string(conn_config):
             conn_type = val
             conn_name = val + "_CONN"
             continue
-        if val.startswith(secret_prefix):
-            val = f"secret-{val[len(secret_prefix) :]}"
         conn_string = conn_string + f"--{key} '{val}' "
     if conn_type != "BigQuery":
         conn_string = (

--- a/src/translation/dvt/main.py
+++ b/src/translation/dvt/main.py
@@ -28,7 +28,7 @@ class ValidationEntity(enum.Enum):
 
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
 COMPOSER_GCS_BUCKET = os.environ.get("COMPOSER_GCS_BUCKET")
-SECRET_PREFIX = "secret:"
+SECRET_PREFIX = "secret-"
 
 
 # create source and traget connection command, supports all type of connections,
@@ -115,7 +115,7 @@ def connection_string(conn_config):
             conn_name = val + "_CONN"
             continue
         if val.startswith(SECRET_PREFIX):
-            val = get_db_password(val[len(SECRET_PREFIX) :])
+            val = get_db_password(val.lstrip(SECRET_PREFIX))
         conn_string = conn_string + f"--{key} '{val}' "
     if conn_type != "BigQuery":
         conn_string = (

--- a/src/translation/dvt/main.py
+++ b/src/translation/dvt/main.py
@@ -115,7 +115,7 @@ def connection_string(conn_config):
             conn_name = val + "_CONN"
             continue
         if val.startswith(SECRET_PREFIX):
-            val = get_db_password(val.lstrip(SECRET_PREFIX))
+            val = get_db_password(val.removeprefix(SECRET_PREFIX))
         conn_string = conn_string + f"--{key} '{val}' "
     if conn_type != "BigQuery":
         conn_string = (

--- a/src/translation/dvt/requirements.txt
+++ b/src/translation/dvt/requirements.txt
@@ -1,7 +1,7 @@
 Flask
 gunicorn
 Werkzeug
-google-pso-data-validator==6.3.0
+google-pso-data-validator==6.2.0
 google-cloud-secret-manager
 hdfs
 thrift-sasl

--- a/src/translation/event_listener/requirements-test.txt
+++ b/src/translation/event_listener/requirements-test.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-pytest==7.4.3
-pytest-mock==3.8.2
+pytest==8.3.3
+pytest-mock==3.14.0

--- a/terraform/translation/gcc/main.tf
+++ b/terraform/translation/gcc/main.tf
@@ -268,13 +268,13 @@ resource "null_resource" "upload_common_utils" {
 /* Set up firewall rule to allow Composer GKE cluster pods (KubernetesPodOperator) to reach the rest of the VPC network. */
 
 data "google_container_cluster" "composer_gke_cluster" {
-  name     = split("/", data.google_composer_environment.composer_env.config.0.gke_cluster)[5]
-  location = split("/", data.google_composer_environment.composer_env.config.0.gke_cluster)[3]
+  name     = split("/", google_composer_environment.composer_env.config.0.gke_cluster)[5]
+  location = split("/", google_composer_environment.composer_env.config.0.gke_cluster)[3]
 }
 
 resource "google_compute_firewall" "dmt-pod-operator" {
   name        = "dmt-allow-composer-gke-pods"
-  network     = data.google_composer_environment.composer_env.config.0.node_config.0.network
+  network     = google_composer_environment.composer_env.config.0.node_config.0.network
   description = "Allows Composer cluster GKE pods to reach the default VPC range."
 
   priority      = 1001


### PR DESCRIPTION
* Adds validation for the input config in controller_dag, such as verifying that GCS buckets, input files, and provided secrets exist.
* Normalizes secret prefix to be `secret-` everywhere, rather than using `secret:` for DVT.