### PR TITLE
Pins Airflow version to 2.9.3

### DIFF
--- a/terraform/translation/gcc/variables.tf
+++ b/terraform/translation/gcc/variables.tf
@@ -26,7 +26,7 @@ variable "location" {
 variable "image_version" {
   type        = string
   description = "The version of the Airflow running in the cloud composer environment."
-  default     = "composer-2-airflow-2"
+  default     = "composer-2-airflow-2.9.3"
 }
 variable "service_account_gcc" {
   type        = string


### PR DESCRIPTION
Sets default Composer image version in Terraform to "composer-2-airflow-2.9.3" (ie. latest Composer with Airflow 2.9.3); Airflow 2.10 includes breaking changes.