### PR TITLE
Fixes Kubernetes pod name import error

### DIFF
--- a/src/translation/dags/validation_dag.py
+++ b/src/translation/dags/validation_dag.py
@@ -22,9 +22,7 @@ from airflow import models
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
 from airflow.operators.python import PythonOperator
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
-    KubernetesPodOperator,
-)
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.google.cloud.operators.cloud_composer import (
     CloudComposerGetEnvironmentOperator,
 )

--- a/terraform/translation/gcc/variables.tf
+++ b/terraform/translation/gcc/variables.tf
@@ -26,7 +26,7 @@ variable "location" {
 variable "image_version" {
   type        = string
   description = "The version of the Airflow running in the cloud composer environment."
-  default     = "composer-2-airflow-2"
+  default     = "composer-2-airflow-2.9.3"
 }
 variable "service_account_gcc" {
   type        = string


### PR DESCRIPTION
Updates kubernetes pod operator name from `kubernetes_pod` to `pod` as updated in [Airflow PR #29905](https://github.com/apache/airflow/pull/29905). Expected to be backwards compatible but currently resulting in import errors.