### PR TITLE
Resolve Airflow deprecation warnings

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -26,10 +26,10 @@ import os
 import nox
 
 # Python version used for linting.
-DEFAULT_PYTHON_VERSION = "3.9"
+DEFAULT_PYTHON_VERSION = "3.11"
 
 # Python versions used for testing.
-PYTHON_VERSIONS = ["3.9", "3.10"]
+PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
 
 LINT_PACKAGES = ["flake8", "black==22.3.0", "isort"]
 

--- a/src/common_utils/operators/reporting_operator.py
+++ b/src/common_utils/operators/reporting_operator.py
@@ -5,7 +5,7 @@ import os
 from airflow.configuration import conf
 from airflow.exceptions import AirflowFailException
 from airflow.models.baseoperator import BaseOperator
-from airflow.utils.log.gcs_task_handler import GCSTaskHandler
+from airflow.providers.google.cloud.log.gcs_task_handler import GCSTaskHandler
 from airflow.utils.state import State
 from google.api_core.client_info import ClientInfo
 from google.cloud import bigquery

--- a/src/datamigration/dags/hive/hive_data_load_dag.py
+++ b/src/datamigration/dags/hive/hive_data_load_dag.py
@@ -59,35 +59,31 @@ with DAG(
     "hive_data_load_dag",
     start_date=datetime(2021, 1, 1),
     max_active_runs=2,
-    schedule_interval=None,
+    schedule=None,
     default_args=default_args,
     catchup=False,
 ) as dag:
     set_required_vars = PythonOperator(
         task_id="set_required_vars",
         python_callable=set_required_vars,
-        provide_context=True,
     )
 
     get_hive_tables = PythonOperator(
         task_id="get_hive_tables",
         python_callable=get_hive_tables,
         op_kwargs={"config": Variable.get("data_load_config", default_var="")},
-        provide_context=True,
     )
 
     get_text_format_schema = PythonOperator(
         task_id="get_text_format_schema",
         python_callable=get_text_format_schema,
         op_kwargs={"config": Variable.get("data_load_config", default_var="")},
-        provide_context=True,
     )
 
     get_partition_clustering_info = PythonOperator(
         task_id="get_partition_clustering_info",
         python_callable=get_partition_clustering_info,
         op_kwargs={"config": Variable.get("data_load_config", default_var="")},
-        provide_context=True,
     )
 
     load_bq_tables = PythonOperator.partial(
@@ -104,7 +100,6 @@ with DAG(
         task_id="invoke_dvt_dag",
         python_callable=invoke_dvt_dag,
         op_kwargs={"config": Variable.get("data_load_config", default_var="")},
-        provide_context=True,
     )
     dag_report = ReportingOperator(
         task_id="dag_report",

--- a/src/datamigration/dags/hive/hive_inc_data_load_dag.py
+++ b/src/datamigration/dags/hive/hive_inc_data_load_dag.py
@@ -70,14 +70,13 @@ with DAG(
     "hive_inc_data_load_dag",
     start_date=datetime(2023, 1, 1),
     max_active_runs=2,
-    schedule_interval=Variable.get("hive_inc_load_schedule_runtime_cron", "0 22 * * *"),
+    schedule=Variable.get("hive_inc_load_schedule_runtime_cron", "0 22 * * *"),
     default_args=default_args,
     catchup=False,
 ) as dag:
     read_config_file = PythonOperator(
         task_id="read_config_file",
         python_callable=read_config_file,
-        provide_context=True,
     )
 
     get_inc_gcs_files = PythonOperator(
@@ -88,7 +87,6 @@ with DAG(
             "bq_pubsub_audit_tbl": bq_pubsub_audit_tbl,
             "schedule_runtime": Variable.get("hive_inc_load_schedule_runtime", ""),
         },
-        provide_context=True,
     )
 
     get_inc_table_list_for_copy = PythonOperator(
@@ -114,7 +112,6 @@ with DAG(
         task_id="get_inc_table_list",
         python_callable=get_inc_table_list,
         op_kwargs={"config": Variable.get("hive_inc_load_config", default_var="")},
-        provide_context=True,
     )
 
     get_table_info_from_metadata = PythonOperator(
@@ -124,21 +121,18 @@ with DAG(
             "config": Variable.get("hive_inc_load_config", default_var=""),
             "bq_audit_dataset_id": bq_audit_dataset_id,
         },
-        provide_context=True,
     )
 
     get_text_format_schema = PythonOperator(
         task_id="get_text_format_schema",
         python_callable=get_text_format_schema,
         op_kwargs={"config": Variable.get("hive_inc_load_config", default_var="")},
-        provide_context=True,
     )
 
     get_partition_clustering_info = PythonOperator(
         task_id="get_partition_clustering_info",
         python_callable=get_partition_clustering_info,
         op_kwargs={"config": Variable.get("hive_inc_load_config", default_var="")},
-        provide_context=True,
     )
 
     load_bq_tables = PythonOperator.partial(

--- a/src/datamigration/dags/redshift/redshift_data_load_dag.py
+++ b/src/datamigration/dags/redshift/redshift_data_load_dag.py
@@ -282,7 +282,7 @@ def _run_bq_transfer_config(batch_idx, ti, **kwargs) -> None:
 
 with models.DAG(
     DAG_ID,
-    schedule_interval=None,
+    schedule=None,
     default_args=default_dag_args,
     render_template_as_native_obj=True,
 ) as dag:

--- a/src/datamigration/dags/redshift/redshift_transfer_run_log_dag.py
+++ b/src/datamigration/dags/redshift/redshift_transfer_run_log_dag.py
@@ -84,7 +84,11 @@ def _load_parameters(ti, **kwargs) -> None:
     tracking_info = dts_logs_utils.get_tracking_info(
         transfer_config_id, BQ_TRANSFER_TRACKING_TABLE_NAME
     )
-    (unique_id, config_bucket_id, config_object_path,) = (
+    (
+        unique_id,
+        config_bucket_id,
+        config_object_path,
+    ) = (
         tracking_info["unique_id"],
         tracking_info["config_bucket_id"],
         tracking_info["config_object_path"],
@@ -330,15 +334,15 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name][
-                            "bq_job_id"
-                        ] = job_summary_match.group(1)
-                        job_stats_jsons[table_name][
-                            "success_records"
-                        ] = job_summary_match.group(3)
-                        job_stats_jsons[table_name][
-                            "error_records"
-                        ] = job_summary_match.group(4)
+                        job_stats_jsons[table_name]["bq_job_id"] = (
+                            job_summary_match.group(1)
+                        )
+                        job_stats_jsons[table_name]["success_records"] = (
+                            job_summary_match.group(3)
+                        )
+                        job_stats_jsons[table_name]["error_records"] = (
+                            job_summary_match.group(4)
+                        )
                     continue
                 # Done
                 elif log_message.__contains__("Summary:"):
@@ -487,7 +491,7 @@ def _determine_validation_dag(ti, **kwargs):
 
 with models.DAG(
     "redshift_transfer_run_log_dag",
-    schedule_interval=None,
+    schedule=None,
     default_args=default_dag_args,
     render_template_as_native_obj=True,
 ) as dag:

--- a/src/datamigration/dags/redshift/redshift_transfer_run_log_dag.py
+++ b/src/datamigration/dags/redshift/redshift_transfer_run_log_dag.py
@@ -84,11 +84,7 @@ def _load_parameters(ti, **kwargs) -> None:
     tracking_info = dts_logs_utils.get_tracking_info(
         transfer_config_id, BQ_TRANSFER_TRACKING_TABLE_NAME
     )
-    (
-        unique_id,
-        config_bucket_id,
-        config_object_path,
-    ) = (
+    (unique_id, config_bucket_id, config_object_path,) = (
         tracking_info["unique_id"],
         tracking_info["config_bucket_id"],
         tracking_info["config_object_path"],
@@ -334,15 +330,15 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name]["bq_job_id"] = (
-                            job_summary_match.group(1)
-                        )
-                        job_stats_jsons[table_name]["success_records"] = (
-                            job_summary_match.group(3)
-                        )
-                        job_stats_jsons[table_name]["error_records"] = (
-                            job_summary_match.group(4)
-                        )
+                        job_stats_jsons[table_name][
+                            "bq_job_id"
+                        ] = job_summary_match.group(1)
+                        job_stats_jsons[table_name][
+                            "success_records"
+                        ] = job_summary_match.group(3)
+                        job_stats_jsons[table_name][
+                            "error_records"
+                        ] = job_summary_match.group(4)
                     continue
                 # Done
                 elif log_message.__contains__("Summary:"):

--- a/src/datamigration/dags/teradata/teradata_data_load_dag.py
+++ b/src/datamigration/dags/teradata/teradata_data_load_dag.py
@@ -368,7 +368,7 @@ def _send_data_to_bq(batch_idx, ti) -> None:
 
 with models.DAG(
     DAG_ID,
-    schedule_interval=None,
+    schedule=None,
     default_args=default_dag_args,
     render_template_as_native_obj=True,
 ) as dag:

--- a/src/datamigration/dags/teradata/teradata_transfer_run_log_dag.py
+++ b/src/datamigration/dags/teradata/teradata_transfer_run_log_dag.py
@@ -94,12 +94,7 @@ def _load_parameters(ti, **kwargs) -> None:
     tracking_info = dts_logs_utils.get_tracking_info(
         transfer_config_id, BQ_TRANSFER_TRACKING_TABLE_NAME
     )
-    (
-        unique_id,
-        agent_id,
-        config_bucket_id,
-        config_object_path,
-    ) = (
+    (unique_id, agent_id, config_bucket_id, config_object_path,) = (
         tracking_info["unique_id"],
         tracking_info["agent_id"],
         tracking_info["config_bucket_id"],
@@ -353,15 +348,15 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name]["agent_id"] = (
-                            extraction_complete_match.group(1)
-                        )
-                        job_stats_jsons[table_name]["extract_duration"] = (
-                            extraction_complete_match.group(3)
-                        )
-                        dts_run_summary_json["agent_id"] = (
-                            extraction_complete_match.group(1)
-                        )
+                        job_stats_jsons[table_name][
+                            "agent_id"
+                        ] = extraction_complete_match.group(1)
+                        job_stats_jsons[table_name][
+                            "extract_duration"
+                        ] = extraction_complete_match.group(3)
+                        dts_run_summary_json[
+                            "agent_id"
+                        ] = extraction_complete_match.group(1)
                     continue
 
                 elif log_message.__contains__("Uploading"):
@@ -373,9 +368,9 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name]["gcs_file_path"] = (
-                            file_path_match.group(2)
-                        )
+                        job_stats_jsons[table_name][
+                            "gcs_file_path"
+                        ] = file_path_match.group(2)
                     continue
 
                 elif log_message.__contains__(": Extracting data"):
@@ -388,18 +383,18 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name]["extract_data_size"] = (
-                            extract_stat_match.group(3)
-                        )
+                        job_stats_jsons[table_name][
+                            "extract_data_size"
+                        ] = extract_stat_match.group(3)
                         job_stats_jsons[table_name]["extract_partitions"] = (
                             "[" + extract_stat_match.group(4) + "]"
                         )
-                        job_stats_jsons[table_name]["extract_files"] = (
-                            extract_stat_match.group(5)
-                        )
-                        job_stats_jsons[table_name]["extract_sessions"] = (
-                            extract_stat_match.group(6)
-                        )
+                        job_stats_jsons[table_name][
+                            "extract_files"
+                        ] = extract_stat_match.group(5)
+                        job_stats_jsons[table_name][
+                            "extract_sessions"
+                        ] = extract_stat_match.group(6)
                     continue
 
                 elif log_message.__contains__(": Running"):
@@ -412,9 +407,9 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name]["transfer_mode"] = (
-                            transfer_mode_match.group(2)
-                        )
+                        job_stats_jsons[table_name][
+                            "transfer_mode"
+                        ] = transfer_mode_match.group(2)
                     continue
 
                 elif log_message.__contains__("Number of records"):
@@ -427,15 +422,15 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name]["bq_job_id"] = (
-                            job_summary_match.group(1)
-                        )
-                        job_stats_jsons[table_name]["success_records"] = (
-                            job_summary_match.group(3)
-                        )
-                        job_stats_jsons[table_name]["error_records"] = (
-                            job_summary_match.group(4)
-                        )
+                        job_stats_jsons[table_name][
+                            "bq_job_id"
+                        ] = job_summary_match.group(1)
+                        job_stats_jsons[table_name][
+                            "success_records"
+                        ] = job_summary_match.group(3)
+                        job_stats_jsons[table_name][
+                            "error_records"
+                        ] = job_summary_match.group(4)
                     continue
 
                 elif log_message.__contains__("Summary:"):

--- a/src/datamigration/dags/teradata/teradata_transfer_run_log_dag.py
+++ b/src/datamigration/dags/teradata/teradata_transfer_run_log_dag.py
@@ -94,7 +94,12 @@ def _load_parameters(ti, **kwargs) -> None:
     tracking_info = dts_logs_utils.get_tracking_info(
         transfer_config_id, BQ_TRANSFER_TRACKING_TABLE_NAME
     )
-    (unique_id, agent_id, config_bucket_id, config_object_path,) = (
+    (
+        unique_id,
+        agent_id,
+        config_bucket_id,
+        config_object_path,
+    ) = (
         tracking_info["unique_id"],
         tracking_info["agent_id"],
         tracking_info["config_bucket_id"],
@@ -348,15 +353,15 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name][
-                            "agent_id"
-                        ] = extraction_complete_match.group(1)
-                        job_stats_jsons[table_name][
-                            "extract_duration"
-                        ] = extraction_complete_match.group(3)
-                        dts_run_summary_json[
-                            "agent_id"
-                        ] = extraction_complete_match.group(1)
+                        job_stats_jsons[table_name]["agent_id"] = (
+                            extraction_complete_match.group(1)
+                        )
+                        job_stats_jsons[table_name]["extract_duration"] = (
+                            extraction_complete_match.group(3)
+                        )
+                        dts_run_summary_json["agent_id"] = (
+                            extraction_complete_match.group(1)
+                        )
                     continue
 
                 elif log_message.__contains__("Uploading"):
@@ -368,9 +373,9 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name][
-                            "gcs_file_path"
-                        ] = file_path_match.group(2)
+                        job_stats_jsons[table_name]["gcs_file_path"] = (
+                            file_path_match.group(2)
+                        )
                     continue
 
                 elif log_message.__contains__(": Extracting data"):
@@ -383,18 +388,18 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name][
-                            "extract_data_size"
-                        ] = extract_stat_match.group(3)
+                        job_stats_jsons[table_name]["extract_data_size"] = (
+                            extract_stat_match.group(3)
+                        )
                         job_stats_jsons[table_name]["extract_partitions"] = (
                             "[" + extract_stat_match.group(4) + "]"
                         )
-                        job_stats_jsons[table_name][
-                            "extract_files"
-                        ] = extract_stat_match.group(5)
-                        job_stats_jsons[table_name][
-                            "extract_sessions"
-                        ] = extract_stat_match.group(6)
+                        job_stats_jsons[table_name]["extract_files"] = (
+                            extract_stat_match.group(5)
+                        )
+                        job_stats_jsons[table_name]["extract_sessions"] = (
+                            extract_stat_match.group(6)
+                        )
                     continue
 
                 elif log_message.__contains__(": Running"):
@@ -407,9 +412,9 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name][
-                            "transfer_mode"
-                        ] = transfer_mode_match.group(2)
+                        job_stats_jsons[table_name]["transfer_mode"] = (
+                            transfer_mode_match.group(2)
+                        )
                     continue
 
                 elif log_message.__contains__("Number of records"):
@@ -422,15 +427,15 @@ def _process_transfer_logs(ti) -> None:
                         if table_name not in job_stats_jsons:
                             job_stats_jsons[table_name] = job_stats_json_template.copy()
                         job_stats_jsons[table_name]["src_table_name"] = table_name
-                        job_stats_jsons[table_name][
-                            "bq_job_id"
-                        ] = job_summary_match.group(1)
-                        job_stats_jsons[table_name][
-                            "success_records"
-                        ] = job_summary_match.group(3)
-                        job_stats_jsons[table_name][
-                            "error_records"
-                        ] = job_summary_match.group(4)
+                        job_stats_jsons[table_name]["bq_job_id"] = (
+                            job_summary_match.group(1)
+                        )
+                        job_stats_jsons[table_name]["success_records"] = (
+                            job_summary_match.group(3)
+                        )
+                        job_stats_jsons[table_name]["error_records"] = (
+                            job_summary_match.group(4)
+                        )
                     continue
 
                 elif log_message.__contains__("Summary:"):
@@ -579,7 +584,7 @@ def _determine_validation_dag(ti, **kwargs):
 
 with models.DAG(
     "teradata_transfer_run_log_dag",
-    schedule_interval=None,
+    schedule=None,
     default_args=default_dag_args,
     render_template_as_native_obj=True,
 ) as dag:

--- a/src/translation/dags/batch_sql_translation.py
+++ b/src/translation/dags/batch_sql_translation.py
@@ -356,7 +356,7 @@ def _save_stats(ti):
 
 with models.DAG(
     "batch_sql_translation",
-    schedule_interval=None,
+    schedule=None,
     default_args=default_dag_args,
     render_template_as_native_obj=True,
 ) as dag:

--- a/src/translation/dags/controller_dag.py
+++ b/src/translation/dags/controller_dag.py
@@ -243,7 +243,7 @@ def _determine_next_dag(ti, **kwargs):
 
 with models.DAG(
     DAG_ID,
-    schedule_interval=None,
+    schedule=None,
     default_args={"start_date": datetime.datetime(2022, 1, 1)},
 ) as dag:
     load_config = PythonOperator(

--- a/src/translation/dags/dml_validation_dag.py
+++ b/src/translation/dags/dml_validation_dag.py
@@ -306,7 +306,7 @@ def _determine_next_dag(ti):
 
 with models.DAG(
     DAG_ID,
-    schedule_interval=None,
+    schedule=None,
     default_args=default_dag_args,
     render_template_as_native_obj=True,
 ) as dag:

--- a/src/translation/dags/extract_ddl_dag.py
+++ b/src/translation/dags/extract_ddl_dag.py
@@ -53,7 +53,7 @@ def _determine_next_taskgroup_from_source(ti, **kwargs):
 with DAG(
     DAG_ID,
     default_args=default_args,
-    schedule_interval=None,
+    schedule=None,
     render_template_as_native_obj=True,
 ) as dag:
     determine_next_taskgroup_from_source = BranchPythonOperator(

--- a/src/translation/dags/schema_dag.py
+++ b/src/translation/dags/schema_dag.py
@@ -173,9 +173,9 @@ def _execute_queries(ti, dag_run):
             "sql_file_name": script.filename[len(LOCAL_DATA_DIRECTORY) + 1 :],
             "job_id": script.get_job().job_id,
             "status": "success" if script.done() else "fail",
-            "error_details": str(script.get_job().exception())
-            if script.failed()
-            else "",
+            "error_details": (
+                str(script.get_job().exception()) if script.failed() else ""
+            ),
             "execution_start_time": str(start_time),
             "gcs_source_path": config["migrationTask"]["translationConfigDetails"][
                 "gcsSourcePath"
@@ -219,7 +219,7 @@ DAG: Schema DAG to create BigQuery Schema from Ouput GCS Bucket SQL Translated f
 """
 with models.DAG(
     DAG_ID,
-    schedule_interval=None,
+    schedule=None,
     default_args=default_dag_args,
     render_template_as_native_obj=True,
 ) as dag:

--- a/src/translation/dags/translation_utils/ddl_extraction_utils/build_oracle_ddl_extraction_group.py
+++ b/src/translation/dags/translation_utils/ddl_extraction_utils/build_oracle_ddl_extraction_group.py
@@ -198,7 +198,6 @@ def build_oracle_ddl_extraction_group(dag: DAG) -> TaskGroup:
         python_callable=_extract_ddl,
         task_group=oracle_extraction_taskgroup,
         dag=dag,
-        provide_context=True,
     )
 
     invoke_batch_translator_dag = TriggerDagRunOperator(

--- a/src/translation/dags/validation_crun_dag.py
+++ b/src/translation/dags/validation_crun_dag.py
@@ -181,7 +181,7 @@ def _save_dvt_aggregated_results(**kwargs):
 
 with models.DAG(
     "validation_crun_dag",
-    schedule_interval=None,
+    schedule=None,
     default_args=default_dag_args,
 ):
     _save_dvt_aggregated_results = _save_dvt_aggregated_results()

--- a/src/translation/dags/validation_dag.py
+++ b/src/translation/dags/validation_dag.py
@@ -381,7 +381,7 @@ def parallelize_dvt_tasks(input_json):
 
 with models.DAG(
     "validation_dag",
-    schedule_interval=None,
+    schedule=None,
     default_args=default_dag_args,
     render_template_as_native_obj=True,
     user_defined_macros={

--- a/src/translation/dags/workload_identity_creator_dag.py
+++ b/src/translation/dags/workload_identity_creator_dag.py
@@ -23,7 +23,7 @@ from airflow.providers.google.cloud.operators.cloud_composer import (
 
 with models.DAG(
     "workload_identity_creator_dag",
-    schedule_interval="@once",
+    schedule="@once",
     default_args={"start_date": datetime.datetime(2022, 1, 1), "retries": 1},
 ) as dag:
     get_env = CloudComposerGetEnvironmentOperator(


### PR DESCRIPTION
Resolves Airflow deprecation warnings:
- Removes `provide_context` from PythonOperator.
- Renames `schedule_interval` to `schedule`.
- Updates path for GCSTaskHandler module.

Also updates Nox default Python version to 3.11 matching the Composer version.

